### PR TITLE
157 update docs to point to projectasaparroyo fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ASAPQuery has four main components: the **asap-planner** generates sketch config
 
 - **[asap-planner](asap-planner/)** - Analyzes a PromQL query workload and auto-generates sketch configurations for asap-sketch-ingest and asap-query-engine
 - **[asap-sketch-ingest](asap-sketch-ingest/)** - Deploys Arroyo streaming pipelines that continuously compute and publish sketches from live metrics
-- **[arroyo](arroyo/)** - Fork of the [Arroyo](https://github.com/ArroyoSystems/Arroyo) stream processing engine that runs the sketch-building SQL pipelines
+- **[arroyo](https://github.com/ProjectASAP/arroyo)** - Fork of the [Arroyo](https://github.com/ArroyoSystems/arroyo) stream processing engine that runs the sketch-building SQL pipelines
 - **[asap-query-engine](asap-query-engine/)** - Intercepts incoming PromQL queries and serves them from pre-computed sketches, falling back to Prometheus for unsupported queries
 
 ### Repository Structure
@@ -59,8 +59,8 @@ ASAPQuery has four main components: the **asap-planner** generates sketch config
 ├── asap-quickstart/         # Self-contained demo (start here!)
 ├── asap-planner/            # Auto-configuration service
 ├── asap-sketch-ingest/      # Arroyo pipeline deployer
-├── arroyo/                  # Fork of Arroyo stream processing engine
 └── asap-query-engine/       # Query serving engine
+# Note: Arroyo fork lives at https://github.com/ProjectASAP/arroyo
 ```
 
 ## Coming soon

--- a/asap-quickstart/README.md
+++ b/asap-quickstart/README.md
@@ -14,7 +14,7 @@ This quickstart simulates a typical monitoring deployment with components you mi
 
 Then it adds ASAPQuery's components on top:
 - **Query Engine** - Prometheus-compatible API with sketch-based acceleration
-- **Arroyo + asap-sketch-ingest** - Streaming engine with pipelines configured for building sketches
+- **[Arroyo](https://github.com/ProjectASAP/arroyo) + asap-sketch-ingest** - Streaming engine with pipelines configured for building sketches
 - **Kafka** - Message broker for streaming data from Arroyo to the Query Engine
 - **asap-planner** - Automatically configures sketches from PromQL queries
 

--- a/docs/01-getting-started/architecture.md
+++ b/docs/01-getting-started/architecture.md
@@ -184,7 +184,7 @@ graph LR
 | Component | Purpose | Technology | Location |
 |-----------|---------|------------|----------|
 | **asap-query-engine** | Answers PromQL queries using sketches | Rust | `asap-query-engine/` |
-| **Arroyo** | Stream processing for building sketches | Rust (forked) | `arroyo/` |
+| **Arroyo** | Stream processing for building sketches | Rust (forked) | [github.com/ProjectASAP/arroyo](https://github.com/ProjectASAP/arroyo) |
 | **asap-sketch-ingest** | Configures Arroyo pipelines from config | Python | `asap-sketch-ingest/` |
 | **asap-planner** | Auto-determines sketch parameters | Python | `asap-planner/` |
 | **Kafka** | Message broker for sketch distribution | Apache Kafka | (external) |
@@ -258,12 +258,6 @@ ASAPQuery/
 │   │   ├── precompute_operators/  # Sketch operators
 │   │   └── tests/            # Integration tests
 │   └── docs/                 # QueryEngine dev docs
-│
-├── arroyo/                   # Arroyo streaming engine (forked)
-│   └── crates/
-│       └── arroyo-connectors/
-│           ├── prometheus_remote_write_with_schema/
-│           └── prometheus_remote_write_optimized/
 │
 ├── asap-sketch-ingest/       # Pipeline configurator
 │   ├── run_arroyosketch.py   # Main script

--- a/docs/02-components/README.md
+++ b/docs/02-components/README.md
@@ -7,7 +7,7 @@ This document provides an overview of all ASAP components and links to detailed 
 | Component | Purpose | Technology | Links |
 |-----------|---------|------------|-------|
 | **asap-query-engine** | Answers PromQL queries using sketches | Rust | [Details](query-engine.md) · [Code](../../asap-query-engine/) · [Dev Docs](../../asap-query-engine/docs/README.md) |
-| **Arroyo** | Stream processing for building sketches | Rust (forked) | [Details](arroyo.md) · [Code](../../arroyo/) |
+| **Arroyo** | Stream processing for building sketches | Rust (forked) | [Details](arroyo.md) · [Code](https://github.com/ProjectASAP/arroyo) |
 | **asap-sketch-ingest** | Configures Arroyo pipelines from config | Python | [Details](arroyosketch.md) · [Code](../../asap-sketch-ingest/) · [README](../../asap-sketch-ingest/README.md) |
 | **asap-planner** | Auto-determines sketch parameters | Python | [Details](controller.md) · [Code](../../asap-planner/) · [README](../../asap-planner/README.md) |
 | **Exporters** | Generate synthetic metrics for testing | Rust/Python | [Details](exporters.md) · [Code](../../asap-tools/prometheus-exporters/) · [README](../../asap-tools/prometheus-exporters/README.md) |


### PR DESCRIPTION
- **Revert sketchlib-rust path dependency workarounds now that repo is public (#160)**
- **Updated docs to point to Arroyo fork**
