### PR TITLE
Rename SimpleMapStore impls to Legacy* (PR #175 split, part a)

### DIFF
--- a/asap-query-engine/benches/simple_store_bench.rs
+++ b/asap-query-engine/benches/simple_store_bench.rs
@@ -1,8 +1,9 @@
-//! Benchmarks for `SimpleMapStore` — insert, range query, exact query,
+//! Benchmarks for `LegacySimpleMapStore` — insert, range query, exact query,
 //! store-analyze, and concurrent reads.
 //!
-//! These benchmarks profile the existing (pre-PR-175) store implementation and
-//! provide concrete measurements of algorithm complexity for:
+//! These benchmarks profile the legacy store implementation
+//! (`LegacySimpleMapStoreGlobal` / `LegacySimpleMapStorePerKey`) and provide
+//! concrete measurements of algorithm complexity for:
 //!
 //! | Operation                          | Expected complexity      |
 //! |------------------------------------|--------------------------|
@@ -67,7 +68,7 @@ fn make_streaming_config(num_agg_ids: u64) -> Arc<StreamingConfig> {
     Arc::new(StreamingConfig::new(configs))
 }
 
-/// Build a `SimpleMapStore` with no cleanup policy.
+/// Build a `SimpleMapStore` (backed by legacy implementation) with no cleanup policy.
 fn make_store(config: Arc<StreamingConfig>, strategy: LockStrategy) -> SimpleMapStore {
     SimpleMapStore::new_with_strategy(config, CleanupPolicy::NoCleanup, strategy)
 }

--- a/asap-query-engine/src/stores/simple_map_store/legacy/global.rs
+++ b/asap-query-engine/src/stores/simple_map_store/legacy/global.rs
@@ -13,7 +13,7 @@ type StoreKey = u64; // aggregation_id
 type StoreValue = Vec<(Option<KeyByLabelValues>, Box<dyn AggregateCore>)>;
 
 /// In-memory storage implementation using single mutex (like Python version)
-pub struct SimpleMapStoreGlobal {
+pub struct LegacySimpleMapStoreGlobal {
     // Single global mutex protecting all data structures
     lock: Mutex<StoreData>,
 
@@ -41,7 +41,7 @@ struct StoreData {
     read_counts: HashMap<StoreKey, HashMap<TimestampRange, u64>>,
 }
 
-impl SimpleMapStoreGlobal {
+impl LegacySimpleMapStoreGlobal {
     pub fn new(streaming_config: Arc<StreamingConfig>, cleanup_policy: CleanupPolicy) -> Self {
         Self {
             lock: Mutex::new(StoreData {
@@ -196,7 +196,7 @@ impl SimpleMapStoreGlobal {
 }
 
 #[async_trait::async_trait]
-impl Store for SimpleMapStoreGlobal {
+impl Store for LegacySimpleMapStoreGlobal {
     fn insert_precomputed_output(
         &self,
         output: PrecomputedOutput,
@@ -543,7 +543,7 @@ impl Store for SimpleMapStoreGlobal {
 
     fn close(&self) -> StoreResult<()> {
         // For in-memory store, no cleanup needed
-        info!("SimpleMapStoreGlobal closed");
+        info!("LegacySimpleMapStoreGlobal closed");
         Ok(())
     }
 }

--- a/asap-query-engine/src/stores/simple_map_store/legacy/mod.rs
+++ b/asap-query-engine/src/stores/simple_map_store/legacy/mod.rs
@@ -1,0 +1,5 @@
+mod global;
+mod per_key;
+
+pub use global::LegacySimpleMapStoreGlobal;
+pub use per_key::LegacySimpleMapStorePerKey;

--- a/asap-query-engine/src/stores/simple_map_store/legacy/per_key.rs
+++ b/asap-query-engine/src/stores/simple_map_store/legacy/per_key.rs
@@ -32,7 +32,7 @@ impl StoreKeyData {
 }
 
 /// In-memory storage implementation using per-key locks for concurrency
-pub struct SimpleMapStorePerKey {
+pub struct LegacySimpleMapStorePerKey {
     // Lock-free concurrent outer map - per aggregation_id
     store: DashMap<StoreKey, Arc<RwLock<StoreKeyData>>>,
 
@@ -48,7 +48,7 @@ pub struct SimpleMapStorePerKey {
     cleanup_policy: CleanupPolicy,
 }
 
-impl SimpleMapStorePerKey {
+impl LegacySimpleMapStorePerKey {
     pub fn new(streaming_config: Arc<StreamingConfig>, cleanup_policy: CleanupPolicy) -> Self {
         Self {
             store: DashMap::new(),
@@ -302,7 +302,7 @@ impl SimpleMapStorePerKey {
 }
 
 #[async_trait::async_trait]
-impl Store for SimpleMapStorePerKey {
+impl Store for LegacySimpleMapStorePerKey {
     fn insert_precomputed_output(
         &self,
         output: PrecomputedOutput,
@@ -632,7 +632,7 @@ impl Store for SimpleMapStorePerKey {
 
     fn close(&self) -> StoreResult<()> {
         // For in-memory store, no cleanup needed
-        info!("SimpleMapStorePerKey closed");
+        info!("LegacySimpleMapStorePerKey closed");
         Ok(())
     }
 }

--- a/asap-query-engine/src/stores/simple_map_store/mod.rs
+++ b/asap-query-engine/src/stores/simple_map_store/mod.rs
@@ -1,5 +1,4 @@
-mod global;
-mod per_key;
+pub mod legacy;
 
 use crate::data_model::{
     AggregateCore, CleanupPolicy, LockStrategy, PrecomputedOutput, StreamingConfig,
@@ -8,13 +7,13 @@ use crate::stores::{Store, StoreResult, TimestampedBucketsMap};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub use global::SimpleMapStoreGlobal;
-pub use per_key::SimpleMapStorePerKey;
+pub use legacy::LegacySimpleMapStoreGlobal;
+pub use legacy::LegacySimpleMapStorePerKey;
 
 /// Enum wrapper that dispatches to either global or per-key lock implementation
 pub enum SimpleMapStore {
-    Global(SimpleMapStoreGlobal),
-    PerKey(SimpleMapStorePerKey),
+    Global(LegacySimpleMapStoreGlobal),
+    PerKey(LegacySimpleMapStorePerKey),
 }
 
 impl SimpleMapStore {
@@ -31,10 +30,10 @@ impl SimpleMapStore {
     ) -> Self {
         match lock_strategy {
             LockStrategy::Global => {
-                SimpleMapStore::Global(SimpleMapStoreGlobal::new(streaming_config, cleanup_policy))
+                SimpleMapStore::Global(LegacySimpleMapStoreGlobal::new(streaming_config, cleanup_policy))
             }
             LockStrategy::PerKey => {
-                SimpleMapStore::PerKey(SimpleMapStorePerKey::new(streaming_config, cleanup_policy))
+                SimpleMapStore::PerKey(LegacySimpleMapStorePerKey::new(streaming_config, cleanup_policy))
             }
         }
     }


### PR DESCRIPTION
## Summary

Split from #175 per reviewer request: this PR contains only the renames and corresponding bench changes.

- Move `SimpleMapStoreGlobal` → `LegacySimpleMapStoreGlobal` into `simple_map_store/legacy/global.rs`
- Move `SimpleMapStorePerKey` → `LegacySimpleMapStorePerKey` into `simple_map_store/legacy/per_key.rs`
- Add `simple_map_store/legacy/mod.rs` re-exporting both types
- Update `simple_map_store/mod.rs`: `SimpleMapStore` enum now wraps the `Legacy*` types via the new `legacy` submodule
- Update `benches/simple_store_bench.rs` doc comment to reflect it benchmarks the legacy store

Public API (`SimpleMapStore`, `Store`) is unchanged — all existing callers compile without modification.

Part (b) (the new optimised inverted-index implementation) will follow in a separate PR.

## Test plan
- [x] `cargo check -p query_engine_rust` passes
- [x] `cargo test -p query_engine_rust` passes (store correctness contract tests from #212)
- [x] Existing benchmark invocation `cargo bench -p query_engine_rust --bench simple_store_bench` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)