### PR TITLE
chore: bump asap_sketchlib to wire-format-align-go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "asap_sketchlib"
 version = "0.1.0"
-source = "git+https://github.com/ProjectASAP/asap_sketchlib?branch=refactor%2Fadopt-sketch-core-modules#d84ff152c7ac7c90b97bf2fbe0d88f28c147d7a6"
+source = "git+https://github.com/ProjectASAP/asap_sketchlib?branch=refactor%2Fwire-format-align-go#d8c0c7f50c99d0e455080e3aa9ecac545c8a070e"
 dependencies = [
  "bytes",
  "prost",
@@ -1603,7 +1603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2339,7 +2339,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2384,7 +2384,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3372,7 +3372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3392,7 +3392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3834,7 +3834,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4181,7 +4181,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4331,7 +4330,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/asap-query-engine/Cargo.toml
+++ b/asap-query-engine/Cargo.toml
@@ -58,7 +58,7 @@ tracing-appender = "0.2"
 arc-swap = "1"
 csv = "1"
 elastic_dsl_utilities.workspace = true
-asap_sketchlib = { git = "https://github.com/ProjectASAP/asap_sketchlib", branch = "refactor/adopt-sketch-core-modules" }
+asap_sketchlib = { git = "https://github.com/ProjectASAP/asap_sketchlib", branch = "refactor/wire-format-align-go" }
 
 [[bin]]
 name = "precompute_engine"


### PR DESCRIPTION
## Summary

Bump the `asap_sketchlib` git dep to `refactor/wire-format-align-go` (asap_sketchlib PR #37), which brings the wire-format `DdSketch` / `CountMinSketch` / `CountSketch` / `HllSketch` types and their `apply_delta` paths into byte-and-semantic parity with sketchlib-go.

ASAPQuery's accumulators only access these types via methods (`merge_refs`, `deserialize_msgpack`, `update`, `estimate`, `rows()/cols()`), never via direct field access. The new fields (`sum`, `sum2`, `l1`, `l2`, `topk`) and the `apply_delta` semantic alignment are transparent to this consumer — no source changes required.

## Test plan
- [x] `cargo test -p query_engine_rust --lib precompute_operators` — 87 passed.
- [x] `cargo build --workspace` — clean.
- [ ] One pre-existing baseline failure (`test_esdsl_time_range_query`) is unrelated to this dep bump (verified by reverting and reproducing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)