### PR TITLE
chore: bump image versions to v0.3.1 in asap-quickstart and asap-dropin

### DIFF
--- a/asap-dropin/docker-compose.yml
+++ b/asap-dropin/docker-compose.yml
@@ -14,7 +14,7 @@ name: asapquery-dropin
 
 services:
   queryengine:
-    image: ghcr.io/projectasap/asap-query-engine:v0.3.0
+    image: ghcr.io/projectasap/asap-query-engine:v0.3.1
     container_name: asap-dropin-queryengine
     hostname: queryengine
     ports:

--- a/asap-quickstart/docker-compose.yml
+++ b/asap-quickstart/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   #############################################################################
 
   asap-planner-rs:
-    image: ghcr.io/projectasap/asap-planner-rs:v0.3.0
+    image: ghcr.io/projectasap/asap-planner-rs:v0.3.1
     container_name: asap-planner-rs
     hostname: asap-planner-rs
     networks:
@@ -99,7 +99,7 @@ services:
   #############################################################################
 
   queryengine:
-    image: ghcr.io/projectasap/asap-query-engine:v0.3.0
+    image: ghcr.io/projectasap/asap-query-engine:v0.3.1
     container_name: asap-queryengine
     hostname: queryengine
     networks:
@@ -141,7 +141,7 @@ services:
 
   # Constant values - baseline for comparison
   fake-exporter-constant:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-constant
     hostname: fake-exporter-constant
     networks:
@@ -163,7 +163,7 @@ services:
 
   # Linear increasing - tests trend preservation
   fake-exporter-linear-up:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-linear-up
     hostname: fake-exporter-linear-up
     networks:
@@ -185,7 +185,7 @@ services:
 
   # Linear decreasing - tests trend preservation
   fake-exporter-linear-down:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-linear-down
     hostname: fake-exporter-linear-down
     networks:
@@ -207,7 +207,7 @@ services:
 
   # Sine wave - tests periodicity preservation
   fake-exporter-sine:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-sine
     hostname: fake-exporter-sine
     networks:
@@ -229,7 +229,7 @@ services:
 
   # Sine with noise - tests signal extraction / smoothing
   fake-exporter-sine-noise:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-sine-noise
     hostname: fake-exporter-sine-noise
     networks:
@@ -251,7 +251,7 @@ services:
 
   # Step function - tests edge preservation
   fake-exporter-step:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-step
     hostname: fake-exporter-step
     networks:
@@ -273,7 +273,7 @@ services:
 
   # Exponential growth - tests non-linear patterns
   fake-exporter-exp-up:
-    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.0
+    image: ghcr.io/projectasap/asap-fake-exporter:v0.3.1
     container_name: asap-fake-exporter-exp-up
     hostname: fake-exporter-exp-up
     networks:


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
