### PR TITLE
fix(query-engine): make fallback HTTP timeout configurable

### DIFF
--- a/asap-query-engine/src/drivers/query/adapters/config.rs
+++ b/asap-query-engine/src/drivers/query/adapters/config.rs
@@ -44,11 +44,18 @@ impl AdapterConfig {
 
     /// Create a configuration for Prometheus HTTP with PromQL
     /// Convenience constructor for backward compatibility
-    pub fn prometheus_promql(fallback_url: String, forward_unsupported: bool) -> Self {
+    pub fn prometheus_promql(
+        fallback_url: String,
+        forward_unsupported: bool,
+        timeout_secs: u64,
+    ) -> Self {
         use crate::drivers::query::fallback::PrometheusHttpFallback;
 
         let fallback = if forward_unsupported {
-            Some(Arc::new(PrometheusHttpFallback::new(fallback_url)) as Arc<dyn FallbackClient>)
+            Some(
+                Arc::new(PrometheusHttpFallback::new(fallback_url, timeout_secs))
+                    as Arc<dyn FallbackClient>,
+            )
         } else {
             None
         };

--- a/asap-query-engine/src/drivers/query/fallback/prometheus.rs
+++ b/asap-query-engine/src/drivers/query/fallback/prometheus.rs
@@ -10,13 +10,15 @@ use tracing::{debug, error};
 pub struct PrometheusHttpFallback {
     client: Client,
     base_url: String,
+    timeout: std::time::Duration,
 }
 
 impl PrometheusHttpFallback {
-    pub fn new(base_url: String) -> Self {
+    pub fn new(base_url: String, timeout_secs: u64) -> Self {
         Self {
             client: Client::new(),
             base_url,
+            timeout: std::time::Duration::from_secs(timeout_secs),
         }
     }
 }
@@ -52,7 +54,7 @@ impl FallbackClient for PrometheusHttpFallback {
             .client
             .get(&full_url)
             .query(&query_params)
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(self.timeout)
             .send()
             .await
         {
@@ -118,7 +120,7 @@ impl FallbackClient for PrometheusHttpFallback {
             .client
             .get(&full_url)
             .query(&query_params)
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(self.timeout)
             .send()
             .await
         {
@@ -171,13 +173,7 @@ impl FallbackClient for PrometheusHttpFallback {
         debug!("Runtime info URL: {}", url);
 
         // Send request to Prometheus
-        match self
-            .client
-            .get(&url)
-            .timeout(std::time::Duration::from_secs(30))
-            .send()
-            .await
-        {
+        match self.client.get(&url).timeout(self.timeout).send().await {
             Ok(response) => {
                 match response.text().await {
                     Ok(text) => {

--- a/asap-query-engine/src/drivers/query/servers/http.rs
+++ b/asap-query-engine/src/drivers/query/servers/http.rs
@@ -678,6 +678,7 @@ mod tests {
         let adapter_config = AdapterConfig::prometheus_promql(
             "http://127.0.0.1:9999".to_string(), // Unused for this test
             false,                               // forward_unsupported_queries
+            30,
         );
 
         let config = HttpServerConfig {

--- a/asap-query-engine/src/engine_config.rs
+++ b/asap-query-engine/src/engine_config.rs
@@ -102,6 +102,9 @@ pub enum BackendConfig {
         /// The server must be reachable at startup.
         #[serde(default)]
         forward_unsupported_queries: bool,
+        /// HTTP timeout in seconds for forwarded queries. Increase for long-range Thanos queries.
+        #[serde(default = "default_fallback_timeout_secs")]
+        fallback_timeout_secs: u64,
     },
     Clickhouse {
         /// ClickHouse HTTP interface base URL.
@@ -141,6 +144,7 @@ impl Default for BackendConfig {
         BackendConfig::Prometheus {
             server: default_prometheus_server(),
             forward_unsupported_queries: false,
+            fallback_timeout_secs: default_fallback_timeout_secs(),
         }
     }
 }
@@ -179,6 +183,10 @@ impl BackendConfig {
 
 fn default_prometheus_server() -> String {
     "http://localhost:9090".to_string()
+}
+
+fn default_fallback_timeout_secs() -> u64 {
+    30
 }
 
 fn default_clickhouse_url() -> String {
@@ -583,6 +591,7 @@ backend:
         if let BackendConfig::Prometheus {
             server,
             forward_unsupported_queries,
+            ..
         } = &config.backend
         {
             assert_eq!(server, "http://prom:9090");

--- a/asap-query-engine/src/main.rs
+++ b/asap-query-engine/src/main.rs
@@ -284,7 +284,12 @@ async fn main() -> Result<()> {
         BackendConfig::Prometheus {
             server,
             forward_unsupported_queries,
-        } => AdapterConfig::prometheus_promql(server.clone(), *forward_unsupported_queries),
+            fallback_timeout_secs,
+        } => AdapterConfig::prometheus_promql(
+            server.clone(),
+            *forward_unsupported_queries,
+            *fallback_timeout_secs,
+        ),
         BackendConfig::Clickhouse {
             url,
             database,

--- a/asap-query-engine/src/tests/prometheus_forwarding_tests.rs
+++ b/asap-query-engine/src/tests/prometheus_forwarding_tests.rs
@@ -106,6 +106,7 @@ async fn setup_test_server(prometheus_port: u16) -> (HttpServer, u16) {
         adapter_config: AdapterConfig::prometheus_promql(
             format!("http://127.0.0.1:{prometheus_port}"),
             true,
+            30,
         ),
     };
 
@@ -199,6 +200,7 @@ async fn test_forwarding_disabled() {
         adapter_config: AdapterConfig::prometheus_promql(
             "http://127.0.0.1:19093".to_string(),
             false, // Forwarding disabled
+            30,
         ),
     };
 
@@ -255,6 +257,7 @@ async fn test_prometheus_server_unreachable() {
         adapter_config: AdapterConfig::prometheus_promql(
             "http://127.0.0.1:99999".to_string(), // Unreachable port
             true,
+            30,
         ),
     };
 
@@ -347,6 +350,7 @@ async fn test_range_query_forwarding_disabled() {
         adapter_config: AdapterConfig::prometheus_promql(
             "http://127.0.0.1:19095".to_string(),
             false, // Forwarding disabled
+            30,
         ),
     };
 
@@ -398,6 +402,7 @@ async fn test_range_query_server_unreachable() {
         adapter_config: AdapterConfig::prometheus_promql(
             "http://127.0.0.1:99998".to_string(), // Unreachable port
             true,
+            30,
         ),
     };
 


### PR DESCRIPTION
- **feat: Elastic DSL in asap-planner-rs (#327)**
- **feat(tools): add experiment script for baseline clickhouse run (#358)**
- **feat(sql-utilities): support multiple SELECT projections with single aggregate (#362)**
- **feat(sql-utilities,query-engine): add SQL ORDER BY and LIMIT support (#364)**
- **fix(query-engine): make fallback HTTP timeout configurable**
