### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.4.0"
+version = "0.5.0"
 
 [workspace.dependencies]
 # Shared external deps (used by 2+ crates)


### PR DESCRIPTION
Bump workspace version from 0.4.0 to 0.5.0 in preparation for the v0.5.0 release.