### PR TITLE
ci: add checkout step to create-release job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,6 +135,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Create GitHub Release
         run: gh release create ${{ github.ref_name }} --generate-notes --title "${{ github.ref_name }}"
         env:


### PR DESCRIPTION
The create-release job was missing actions/checkout, causing gh release create --generate-notes to fail with 'not a git repository'.