### PR TITLE
fix(asap-planner): use MinMax with grouping for 1s spatial SQL MIN/MAX instead of MultipleMinMax

### DIFF
--- a/asap-planner-rs/src/planner/sql.rs
+++ b/asap-planner-rs/src/planner/sql.rs
@@ -114,7 +114,7 @@ impl SQLSingleQueryProcessor {
             all_metadata.difference(&spatial_output)
         };
 
-        let configs = build_agg_configs_for_statistics(
+        let mut configs = build_agg_configs_for_statistics(
             &statistics,
             treatment_type,
             &spatial_output,
@@ -134,6 +134,23 @@ impl SQLSingleQueryProcessor {
             },
         )
         .map_err(ControllerError::SqlParse)?;
+
+        // 1s spatial MIN/MAX: single MinMax per GROUP BY key (not MultipleMinMax subpopulations).
+        if matches!(query_type, QueryType::Spatial) {
+            match agg_info.get_name().to_uppercase().as_str() {
+                "MIN" | "MAX" => {
+                    let sub_type = agg_info.get_name().to_lowercase();
+                    for cfg in &mut configs {
+                        cfg.aggregation_type = AggregationType::MinMax;
+                        cfg.aggregation_sub_type = sub_type.clone();
+                        cfg.grouping_labels = spatial_output.clone();
+                        cfg.aggregated_labels = KeyByLabelNames::empty();
+                        cfg.rollup_labels = KeyByLabelNames::empty();
+                    }
+                }
+                _ => {}
+            }
+        }
 
         let t_lookback = match query_type {
             QueryType::Spatial => self.data_ingestion_interval,

--- a/asap-planner-rs/tests/sql_integration.rs
+++ b/asap-planner-rs/tests/sql_integration.rs
@@ -476,6 +476,39 @@ fn spatial_count_distinct_hll() {
     );
 }
 
+/// 1s spatial MAX(pkt_len) GROUP BY dstip → MinMax (max), grouping [dstip], empty rollup.
+#[test]
+fn spatial_max_pkt_len() {
+    let q = "SELECT dstip, MAX(pkt_len) AS max_pkt_len FROM netflow_table WHERE time BETWEEN DATEADD(s, -11, NOW()) AND DATEADD(s, -10, NOW()) GROUP BY dstip";
+    let out = SQLController::from_yaml(&netflow_one_query_config(q, 1), sql_opts_1s_ingest())
+        .unwrap()
+        .generate()
+        .unwrap();
+
+    assert_eq!(out.streaming_aggregation_count(), 1);
+    assert_eq!(out.inference_query_count(), 1);
+    assert!(out.has_aggregation_type("MinMax"));
+    assert!(out.has_aggregation_type_and_sub_type("MinMax", "max"));
+    assert!(!out.has_aggregation_type("MultipleMinMax"));
+    assert!(out.all_tumbling_window_sizes_eq(1));
+    assert_eq!(
+        out.aggregation_value_column("MinMax"),
+        Some("pkt_len".to_string())
+    );
+    assert_eq!(
+        out.aggregation_labels("MinMax", "grouping"),
+        vec!["dstip".to_string()]
+    );
+    assert_eq!(
+        out.aggregation_labels("MinMax", "rollup"),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        out.aggregation_labels("MinMax", "aggregated"),
+        Vec::<String>::new()
+    );
+}
+
 // ── T-value variants for SUM (range = 300 s fixed) ───────────────────────────
 //
 // These three tests use the same query and differ only in repetition_delay (T).


### PR DESCRIPTION
## Code Changes Summary  

### `asap-planner-rs/src/planner/sql.rs`

#### Before (default behavior)
Spatial `MIN` / `MAX` queries used:
- **Aggregation:** `MultipleMinMax`  
- **grouping:** `[]`  
- **aggregated:** `[GROUP BY columns]`  
- **rollup:** `[other metadata columns]`  

---

#### After

- Introduced `let mut configs` to allow post-processing updates  

- **Spatial `MIN` / `MAX` fix**  
  (applies only to `QueryType::Spatial` + `"MIN"` / `"MAX"`):
  - `aggregation_type` → `MinMax`  
  - `aggregation_sub_type` → `"min"` or `"max"`  
  - `grouping_labels` → SQL `GROUP BY` columns (`spatial_output`)  
  - `aggregated_labels` → `[]`  
  - `rollup_labels` → `[]`  

---

#### Unchanged
- Temporal / spatiotemporal `MIN` / `MAX` still use `MultipleMinMax`  

---

### `asap-planner-rs/tests/sql_integration.rs`

#### New Test: `spatial_max_pkt_len`

- **Query:**  
  `MAX(pkt_len) ... GROUP BY dstip` (1-second window, `netflow_table`)

---

## Runtime Impact (Generated Config)

| Field       | Before              | After                     |
|------------|--------------------|---------------------------|
| Type       | MultipleMinMax     | MinMax                    |
| grouping   | []                 | [dstip] (GROUP BY cols)   |
| aggregated | [dstip]            | []                        |
| rollup     | e.g. [srcip, proto]| []                        |

---

## Result

- Aligns planner output with:
  - query engine expectations  
  - ingest sharding (group-by as store key)  