### PR TITLE
chore(tools): add script to install local dependencies for experiment orchestrators

### DIFF
--- a/asap-tools/README.md
+++ b/asap-tools/README.md
@@ -12,6 +12,11 @@ A framework for running end-to-end distributed systems experiments on CloudLab, 
   - Ubuntu
   - Python 3.8+
   - Local clone of `ASAPQuery` repo (at `$REPO_ROOT`)
+  - Dependencies for running the experiment orchestrators (`experiment_run_e2e.py`, `experiment_run_clickhouse.py`, etc.):
+    ```bash
+    cd $REPO_ROOT/asap-tools/experiments
+    ./setup_dependencies.sh
+    ```
 
 - **CloudLab:**
   - Active experiment with N nodes

--- a/asap-tools/experiments/requirements.txt
+++ b/asap-tools/experiments/requirements.txt
@@ -1,0 +1,4 @@
+hydra-core==1.3.2
+omegaconf==2.3.0
+Jinja2==3.1.2
+PyYAML==6.0.2

--- a/asap-tools/experiments/requirements.txt
+++ b/asap-tools/experiments/requirements.txt
@@ -2,3 +2,9 @@ hydra-core==1.3.2
 omegaconf==2.3.0
 Jinja2==3.1.2
 PyYAML==6.0.2
+humanize==4.9.0
+matplotlib==3.7.1
+msgpack==1.1.0
+numpy>=1.26,<2
+pandas==2.0.3
+plotnine==0.12.4

--- a/asap-tools/experiments/setup_dependencies.sh
+++ b/asap-tools/experiments/setup_dependencies.sh
@@ -13,3 +13,6 @@ THIS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 sudo apt-get update
 sudo apt-get install -y python3-pip rsync openssh-client
 pip3 install --user -r "${THIS_DIR}/requirements.txt"
+
+# promql_utilities (used by post_experiment/) isn't on PyPI, install local editable copy
+pip3 install --user -e "${THIS_DIR}/../../asap-common/dependencies/py/promql_utilities"

--- a/asap-tools/experiments/setup_dependencies.sh
+++ b/asap-tools/experiments/setup_dependencies.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Installs the dependencies needed to run the experiment orchestrators
+# (experiment_run_e2e.py, experiment_run_clickhouse.py, etc.) from the local
+# machine. These scripts only drive remote CloudLab nodes over ssh/rsync; all
+# component installation on the nodes themselves is handled by
+# asap-tools/deploy_from_scratch.sh.
+
+set -e
+
+THIS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
+sudo apt-get update
+sudo apt-get install -y python3-pip rsync openssh-client
+pip3 install --user -r "${THIS_DIR}/requirements.txt"


### PR DESCRIPTION
experiment_run_e2e.py and experiment_run_clickhouse.py had no documented
or scripted way to install the Python packages they need to run locally
(hydra-core, omegaconf, Jinja2, PyYAML).

Fixes #399

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
