### PR TITLE
fix(tools): pin TZ=UTC across ClickHouse experiment configs

### DIFF
--- a/asap-planner-rs/docker-compose.yml.j2
+++ b/asap-planner-rs/docker-compose.yml.j2
@@ -2,6 +2,11 @@ services:
   controller:
     image: sketchdb-controller:latest
     container_name: {{ container_name }}
+    environment:
+      # Naive datetime-string time literals in SQL queries must parse the
+      # same way here as in ClickHouse (UTC by default) and in bare-metal
+      # asap-planner (see experiment_utils/services/misc.py).
+      - TZ=UTC
     volumes:
       - {{ input_config_path }}:/app/input/config.yaml:ro
       - {{ output_dir }}:/app/output

--- a/asap-query-engine/docker-compose.yml.j2
+++ b/asap-query-engine/docker-compose.yml.j2
@@ -10,6 +10,10 @@ services:
     environment:
       - RUST_LOG={{ log_level }}
       - RUST_BACKTRACE=1
+      # Naive datetime-string time literals in incoming SQL queries must parse
+      # the same way here as in ClickHouse (UTC by default) and in bare-metal
+      # query_engine_rust (see experiment_utils/services/query_engine.py).
+      - TZ=UTC
     ports:
       - "{{ http_port }}:8088"
     network_mode: "host"

--- a/asap-tools/experiments/experiment_utils/services/docker-compose.clickhouse.yml.j2
+++ b/asap-tools/experiments/experiment_utils/services/docker-compose.clickhouse.yml.j2
@@ -11,6 +11,10 @@ services:
     environment:
       - CLICKHOUSE_DB={{ database }}
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      # Explicit rather than relying on the image's default: naive datetime-
+      # string time literals in SQL queries must parse identically here and
+      # in asap-planner/query_engine_rust (both pinned to TZ=UTC too).
+      - TZ=UTC
     ulimits:
       nofile:
         soft: 262144

--- a/asap-tools/experiments/experiment_utils/services/misc.py
+++ b/asap-tools/experiments/experiment_utils/services/misc.py
@@ -257,8 +257,13 @@ class ControllerService(BaseService):
         query_language: str,
     ) -> None:
         controller_log = os.path.join(controller_remote_output_dir, "controller.log")
+        # Force UTC so naive (no Z/offset) datetime-string time literals in SQL
+        # queries parse identically here (parse_datetime, sqlpattern_parser.rs)
+        # and in ClickHouse (whose container has no TZ override, so it defaults
+        # to UTC) -- otherwise the two would silently disagree by the shell's
+        # local UTC offset.
         cmd = (
-            f"../target/release/asap-planner"
+            f"TZ=UTC ../target/release/asap-planner"
             f" --input_config {controller_input_file}"
             f" --output_dir {controller_remote_output_dir}"
             f" --streaming_engine {streaming_engine}"

--- a/asap-tools/experiments/experiment_utils/services/query_engine.py
+++ b/asap-tools/experiments/experiment_utils/services/query_engine.py
@@ -333,8 +333,17 @@ class QueryEngineRustService(BaseQueryEngineService):
         cmd_dir = os.path.join(
             self.provider.get_home_dir(), "code", "asap-query-engine"
         )
+        # Force UTC so naive datetime-string time literals in incoming SQL
+        # queries parse the same way here as in ClickHouse (UTC by default)
+        # and in asap-planner (see misc.py's ControllerService for the same
+        # fix) -- otherwise absolute-timestamp queries could silently
+        # disagree by the shell's local UTC offset.
         cmd = (
-            f"../target/release/query_engine_rust"
+            # `env` (not a bare `TZ=UTC` prefix) since this runs under nohup,
+            # which execs argv[0] directly rather than re-parsing through a
+            # shell -- a bare `VAR=val` prefix would make nohup try (and
+            # fail) to exec "TZ=UTC" itself as the program name.
+            f"env TZ=UTC ../target/release/query_engine_rust"
             f" --config-file {output_dir}/engine_config.yaml"
             f" > {output_dir}/query_engine_rust.out 2>&1 &"
         )


### PR DESCRIPTION
## Summary
- Pin `TZ=UTC` in the ClickHouse, asap-planner, and query-engine docker-compose configs and remote-launch commands so naive datetime-string time literals in SQL queries parse identically everywhere (previously could silently disagree by the shell's local UTC offset vs. ClickHouse's UTC default).

Split out of #514, which mixed this with unrelated changes (sketch_parameters threading, init_sql_file rsync, clickhouse image_tag). Those are in #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)