### PR TITLE
refactor(query-engine): rename range's window_mode to step_overlap_mode

### DIFF
--- a/asap-query-engine/src/engines/simple_engine/mod.rs
+++ b/asap-query-engine/src/engines/simple_engine/mod.rs
@@ -1589,7 +1589,11 @@ impl SimpleEngine {
         let keys_lookback_ms = context.keys_lookback_ms;
         let keys_tumbling_window_ms = context.keys_tumbling_window_ms;
 
-        let window_mode = if buckets_per_step <= lookback_bucket_count {
+        // Named distinctly from `WindowType` (Sliding/Tumbling, picks the store
+        // fetch call) -- this describes step-to-step overlap in the OUTPUT
+        // iteration, an unrelated concept that happens to reuse the words
+        // "sliding"/"hopping". See #581.
+        let step_overlap_mode = if buckets_per_step <= lookback_bucket_count {
             "sliding (slide <= size)"
         } else {
             "hopping (slide > size)"
@@ -1603,7 +1607,7 @@ impl SimpleEngine {
             tumbling_window_ms,
             buckets_per_step,
             lookback_bucket_count,
-            window_mode
+            step_overlap_mode
         );
 
         // Whether the value accumulator's own get_keys() is even consulted


### PR DESCRIPTION
Stage A of #581. Renames a range-pipeline debug-log local so it stops colliding in name with `WindowType` (Sliding/Tumbling, picks the store fetch call) — unrelated concept, same words. Zero behavior change.

Part of #581.