### PR TITLE
chore: gate legacy stores behind a feature flag

### DIFF
--- a/asap-query-engine/Cargo.toml
+++ b/asap-query-engine/Cargo.toml
@@ -87,6 +87,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "simple_store_bench"
 harness = false
+required-features = ["legacy_stores"]
 
 [features]
 #default = ["lock_profiling", "extra_debugging"]
@@ -97,3 +98,8 @@ jemalloc = ["dep:tikv-jemallocator"]
 lock_profiling = []
 # Enable extra debugging output
 extra_debugging = []
+# Legacy SimpleMapStore implementations, kept only for the simple_store_bench
+# comparison benchmark. Off by default so the Store trait's real implementors
+# are just SimpleMapStoreGlobal/PerKey — adding a Store trait method doesn't
+# require updating the legacy variants.
+legacy_stores = []

--- a/asap-query-engine/src/stores/simple_map_store/mod.rs
+++ b/asap-query-engine/src/stores/simple_map_store/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 pub mod global;
+#[cfg(feature = "legacy_stores")]
 pub mod legacy;
 pub mod per_key;
 


### PR DESCRIPTION
## Summary
- `LegacySimpleMapStoreGlobal`/`LegacySimpleMapStorePerKey` implement the `Store` trait but are only exercised by the `simple_store_bench` comparison benchmark — no production code path uses them.
- Added an off-by-default `legacy_stores` Cargo feature; gated `pub mod legacy;` behind it and made the bench target require it (`required-features`).
- Effect: default `cargo build/check/test` no longer compiles the legacy `Store` impls, so future changes to the `Store` trait don't need to touch the legacy variants. Run `cargo bench --features legacy_stores` when the comparison benchmark is actually needed.

## Test plan
- [x] `cargo check -p query_engine_rust` (default features) builds clean
- [x] `cargo check -p query_engine_rust --benches --features legacy_stores` builds clean
- [x] `cargo check -p query_engine_rust --benches` (default features) skips the bench target with no error