### PR TITLE
feat(asap-tools): add frame-pointer query engine profiling

### DIFF
--- a/asap-query-engine/Cargo.toml
+++ b/asap-query-engine/Cargo.toml
@@ -65,6 +65,14 @@ asap_sketchlib.workspace = true
 tikv-jemallocator = { version = "0.6", optional = true }
 
 [[bin]]
+name = "query_engine_rust"
+path = "src/main.rs"
+
+[[bin]]
+name = "query_engine_rust_fp"
+path = "src/main.rs"
+
+[[bin]]
 name = "precompute_engine"
 path = "src/bin/precompute_engine.rs"
 

--- a/asap-query-engine/installation/install.sh
+++ b/asap-query-engine/installation/install.sh
@@ -9,7 +9,17 @@ source "$HOME/.cargo/env"
 
 echo "Building QueryEngine Rust binary..."
 cd "$PARENT_DIR"
-cargo build --release
+cargo build --release -p query_engine_rust
+cp ../target/release/query_engine_rust ../target/release/query_engine_rust_normal
+
+echo "Building frame-pointer QueryEngine Rust binary..."
+fp_rustflags="${RUSTFLAGS:-}"
+fp_rustflags="${fp_rustflags:+$fp_rustflags }-C force-frame-pointers=yes"
+RUSTFLAGS="$fp_rustflags" cargo build --release -p query_engine_rust
+mv ../target/release/query_engine_rust ../target/release/query_engine_rust_fp
+mv ../target/release/query_engine_rust_normal ../target/release/query_engine_rust
+
+echo "Built normal and frame-pointer QueryEngine Rust binaries."
 
 echo "Building QueryEngine Rust Docker image..."
 cd "$(dirname "$PARENT_DIR")"

--- a/asap-query-engine/installation/install.sh
+++ b/asap-query-engine/installation/install.sh
@@ -10,14 +10,11 @@ source "$HOME/.cargo/env"
 echo "Building QueryEngine Rust binary..."
 cd "$PARENT_DIR"
 cargo build --release -p query_engine_rust
-cp ../target/release/query_engine_rust ../target/release/query_engine_rust_normal
 
 echo "Building frame-pointer QueryEngine Rust binary..."
 fp_rustflags="${RUSTFLAGS:-}"
 fp_rustflags="${fp_rustflags:+$fp_rustflags }-C force-frame-pointers=yes"
-RUSTFLAGS="$fp_rustflags" cargo build --release -p query_engine_rust
-mv ../target/release/query_engine_rust ../target/release/query_engine_rust_fp
-mv ../target/release/query_engine_rust_normal ../target/release/query_engine_rust
+RUSTFLAGS="$fp_rustflags" cargo build --release -p query_engine_rust --bin query_engine_rust_fp
 
 echo "Built normal and frame-pointer QueryEngine Rust binaries."
 

--- a/asap-tools/docs/configuration.md
+++ b/asap-tools/docs/configuration.md
@@ -177,8 +177,8 @@ All profiling options are in the `profiling` section and are **monitoring** feat
 profiling.query_engine=true
 ```
 
-**Output:** Raw `perf.data` recordings and `perf archive` symbol archives are
-saved to the experiment output directory. Run
+**Output:** Raw `perf.data` recordings and remote `perf script --header` output
+are saved to the experiment output directory. Run
 `experiments/postprocess_query_engine_profiles.sh` locally after the experiment
 to generate scripts, folded stacks, and flamegraphs.
 

--- a/asap-tools/docs/configuration.md
+++ b/asap-tools/docs/configuration.md
@@ -167,8 +167,9 @@ All profiling options are in the `profiling` section and are **monitoring** feat
 **Type:** `bool`
 **Default:** `false`
 **Category:** Monitoring
-**Description:** Enable CPU and memory profiling of the query engine process using `py-spy`.
-**Captures:** Function call stacks, CPU time per function, heap allocations
+**Description:** Enable CPU profiling of the bare-metal Rust query engine using
+`perf` with frame-pointer call chains.
+**Captures:** Function call stacks and sampled CPU time per function
 **Note:** (TODO) I believe this only works for the older Python based QueryEngine, not QueryEngineRust
 
 **Example:**
@@ -176,7 +177,10 @@ All profiling options are in the `profiling` section and are **monitoring** feat
 profiling.query_engine=true
 ```
 
-**Output:** Profiling data saved to experiment output directory.
+**Output:** Raw `perf.data` recordings and `perf archive` symbol archives are
+saved to the experiment output directory. Run
+`experiments/postprocess_query_engine_profiles.sh` locally after the experiment
+to generate scripts, folded stacks, and flamegraphs.
 
 ### profiling.prometheus_time
 

--- a/asap-tools/docs/query-engine-profiling.md
+++ b/asap-tools/docs/query-engine-profiling.md
@@ -1,0 +1,25 @@
+# Query engine profiling
+
+Set `profiling.query_engine: true` and
+`use_container.query_engine: false` for a Rust query-engine profile.
+
+The remote workflow builds and launches the separate
+`target/release/query_engine_rust_fp` binary, records compact frame-pointer
+call chains with `perf record`, and archives the symbols with `perf archive`.
+It does not run `perf script` remotely.
+
+After `experiment_run_e2e.py` rsyncs the experiment output back locally, run:
+
+```bash
+./asap-tools/experiments/postprocess_query_engine_profiles.sh \
+  experiment_outputs/<experiment>/sketchdb/query_engine_profiles
+```
+
+This produces, for each `perf_*.data` file:
+
+- `.script`: symbolized Perf samples;
+- `.folded`: collapsed stacks for Speedscope or FlameGraph;
+- `.svg`: a browser-viewable flamegraph.
+
+The script uses `/tmp/FlameGraph` by default. Pass a different FlameGraph
+directory as its second argument when needed.

--- a/asap-tools/docs/query-engine-profiling.md
+++ b/asap-tools/docs/query-engine-profiling.md
@@ -5,8 +5,9 @@ Set `profiling.query_engine: true` and
 
 The remote workflow builds and launches the separate
 `target/release/query_engine_rust_fp` binary, records compact frame-pointer
-call chains with `perf record`, and archives the symbols with `perf archive`.
-It does not run `perf script` remotely.
+call chains with `perf record`, and converts the recording to a symbolized
+`perf.script` with `perf script --header` on the remote node. FP makes this
+conversion fast enough to complete before the experiment output is rsynced.
 
 After `experiment_run_e2e.py` rsyncs the experiment output back locally, run:
 
@@ -15,7 +16,8 @@ After `experiment_run_e2e.py` rsyncs the experiment output back locally, run:
   experiment_outputs/<experiment>/sketchdb/query_engine_profiles
 ```
 
-This produces, for each `perf_*.data` file:
+This reuses the remote `.script` file when present and produces, for each
+`perf_*.data` file:
 
 - `.script`: symbolized Perf samples;
 - `.folded`: collapsed stacks for Speedscope or FlameGraph;

--- a/asap-tools/experiments/constants.py
+++ b/asap-tools/experiments/constants.py
@@ -15,6 +15,8 @@ FLINK_OUTPUT_TOPIC = "flink_output"
 KAFKA_BROKER = "localhost:9092"
 
 QUERY_ENGINE_RS_PROCESS_KEYWORD = "query_engine_rust"
+QUERY_ENGINE_RS_BINARY_NAME = "query_engine_rust"
+QUERY_ENGINE_RS_FP_BINARY_NAME = "query_engine_rust_fp"
 QUERY_ENGINE_RS_CONTAINER_NAME = "sketchdb-queryengine-rust"
 
 ARROYO_IMAGE = "ghcr.io/projectasap/asap-arroyo:v0.1.0"

--- a/asap-tools/experiments/experiment_run_clickhouse.py
+++ b/asap-tools/experiments/experiment_run_clickhouse.py
@@ -427,7 +427,7 @@ def main(cfg: DictConfig) -> None:
                 flink_output_format="json",
                 data_ingestion_interval_ms=data_ingestion_interval_ms,
                 log_level="INFO",
-                profile_query_engine=False,
+                profile_query_engine=profile_query_engine,
                 manual=False,
                 streaming_engine="precompute",
                 controller_remote_output_dir=remote_controller_dir,

--- a/asap-tools/experiments/experiment_utils/services/query_engine.py
+++ b/asap-tools/experiments/experiment_utils/services/query_engine.py
@@ -361,8 +361,6 @@ class QueryEngineRustService(BaseQueryEngineService):
             # which execs argv[0] directly rather than re-parsing through a
             # shell -- a bare `VAR=val` prefix would make nohup try (and
             # fail) to exec "TZ=UTC" itself as the program name.
-            f"test -x {binary_path} || "
-            f"{{ echo 'Missing query engine binary: {binary_path}'; exit 1; }}; "
             f"env TZ=UTC {binary_path}"
             f" --config-file {output_dir}/engine_config.yaml"
             f" > {output_dir}/query_engine_rust.out 2>&1 &"

--- a/asap-tools/experiments/experiment_utils/services/query_engine.py
+++ b/asap-tools/experiments/experiment_utils/services/query_engine.py
@@ -306,6 +306,27 @@ class QueryEngineRustService(BaseQueryEngineService):
         """Start Rust QueryEngine using bare metal deployment."""
         output_dir = os.path.join(experiment_output_dir, "query_engine_output")
         local_output_dir = os.path.join(local_experiment_dir, "query_engine_output")
+        cmd_dir = os.path.join(
+            self.provider.get_home_dir(), "code", "asap-query-engine"
+        )
+        binary_name = (
+            constants.QUERY_ENGINE_RS_FP_BINARY_NAME
+            if profile_query_engine
+            else constants.QUERY_ENGINE_RS_BINARY_NAME
+        )
+        binary_path = f"../target/release/{binary_name}"
+
+        if profile_query_engine and not manual:
+            # Check on the target node before writing config or starting the
+            # service, so a profiling run cannot silently use a non-FP binary.
+            self.provider.execute_command(
+                node_idx=self.node_offset,
+                cmd=f"test -x {binary_path}",
+                cmd_dir=cmd_dir,
+                nohup=False,
+                popen=False,
+                ignore_errors=False,
+            )
 
         config = self._build_engine_config(
             output_dir=output_dir,
@@ -330,9 +351,6 @@ class QueryEngineRustService(BaseQueryEngineService):
             remote_path=os.path.join(output_dir, "engine_config.yaml"),
         )
 
-        cmd_dir = os.path.join(
-            self.provider.get_home_dir(), "code", "asap-query-engine"
-        )
         # Force UTC so naive datetime-string time literals in incoming SQL
         # queries parse the same way here as in ClickHouse (UTC by default)
         # and in asap-planner (see misc.py's ControllerService for the same
@@ -343,7 +361,9 @@ class QueryEngineRustService(BaseQueryEngineService):
             # which execs argv[0] directly rather than re-parsing through a
             # shell -- a bare `VAR=val` prefix would make nohup try (and
             # fail) to exec "TZ=UTC" itself as the program name.
-            f"env TZ=UTC ../target/release/query_engine_rust"
+            f"test -x {binary_path} || "
+            f"{{ echo 'Missing query engine binary: {binary_path}'; exit 1; }}; "
+            f"env TZ=UTC {binary_path}"
             f" --config-file {output_dir}/engine_config.yaml"
             f" > {output_dir}/query_engine_rust.out 2>&1 &"
         )

--- a/asap-tools/experiments/postprocess_query_engine_profiles.sh
+++ b/asap-tools/experiments/postprocess_query_engine_profiles.sh
@@ -35,14 +35,7 @@ for data_file in "${data_files[@]}"; do
     script_file="$stem.script"
     folded_file="$stem.folded"
     svg_file="$stem.svg"
-    archive_file="$data_file.tar.bz2"
-    symfs_directory="${stem}.symbols"
-
-    if [[ -f "$archive_file" ]]; then
-        mkdir -p "$symfs_directory"
-        tar --overwrite -xjf "$archive_file" -C "$symfs_directory"
-        perf script --header -i "$data_file" --symfs "$symfs_directory" > "$script_file"
-    else
+    if [[ ! -f "$script_file" ]]; then
         perf script --header -i "$data_file" > "$script_file"
     fi
 

--- a/asap-tools/experiments/postprocess_query_engine_profiles.sh
+++ b/asap-tools/experiments/postprocess_query_engine_profiles.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 PROFILE_DIRECTORY [FLAMEGRAPH_DIRECTORY]" >&2
+    exit 2
+fi
+
+PROFILE_DIRECTORY=$(readlink -f "$1")
+FLAMEGRAPH_DIRECTORY=$(readlink -f "${2:-/tmp/FlameGraph}")
+
+[[ -d "$PROFILE_DIRECTORY" ]] || {
+    echo "Profile directory does not exist: $PROFILE_DIRECTORY" >&2
+    exit 1
+}
+[[ -x "$FLAMEGRAPH_DIRECTORY/stackcollapse-perf.pl" ]] || {
+    echo "Missing stackcollapse-perf.pl in $FLAMEGRAPH_DIRECTORY" >&2
+    exit 1
+}
+[[ -x "$FLAMEGRAPH_DIRECTORY/flamegraph.pl" ]] || {
+    echo "Missing flamegraph.pl in $FLAMEGRAPH_DIRECTORY" >&2
+    exit 1
+}
+
+shopt -s nullglob
+data_files=("$PROFILE_DIRECTORY"/perf_*.data)
+(( ${#data_files[@]} > 0 )) || {
+    echo "No perf_*.data files found in $PROFILE_DIRECTORY" >&2
+    exit 1
+}
+
+for data_file in "${data_files[@]}"; do
+    stem=${data_file%.data}
+    script_file="$stem.script"
+    folded_file="$stem.folded"
+    svg_file="$stem.svg"
+    archive_file="$data_file.tar.bz2"
+    symfs_directory="${stem}.symbols"
+
+    if [[ -f "$archive_file" ]]; then
+        mkdir -p "$symfs_directory"
+        tar --overwrite -xjf "$archive_file" -C "$symfs_directory"
+        perf script --header -i "$data_file" --symfs "$symfs_directory" > "$script_file"
+    else
+        perf script --header -i "$data_file" > "$script_file"
+    fi
+
+    "$FLAMEGRAPH_DIRECTORY/stackcollapse-perf.pl" \
+        "$script_file" > "$folded_file"
+    "$FLAMEGRAPH_DIRECTORY/flamegraph.pl" \
+        --colors hot \
+        --title "Query Engine profile: $(basename "$data_file")" \
+        "$folded_file" > "$svg_file"
+
+    echo "Wrote $script_file"
+    echo "Wrote $folded_file"
+    echo "Wrote $svg_file"
+done

--- a/asap-tools/experiments/remote_monitor.py
+++ b/asap-tools/experiments/remote_monitor.py
@@ -5,6 +5,7 @@ import argparse
 import subprocess
 import yaml
 import signal
+import tempfile
 from loguru import logger
 
 from typing import List
@@ -174,7 +175,11 @@ def start_profiling_query_engine_pids(qe_pids, experiment_output_dir):
             "record",
             "-g",
             "--call-graph",
-            "dwarf",
+            # The QE binary must be built with frame pointers enabled, e.g.
+            # RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release.
+            # FP unwinding avoids the expensive DWARF stack post-unwinding
+            # while retaining call-chain data for perf report/script.
+            "fp",
             "-F",
             "99",
             "-o",
@@ -212,7 +217,7 @@ def stop_profiling_query_engine_pids(qe_perf_procs, store: bool):
     logger.debug("Stopped profiling for query engine pids")
 
 
-def convert_query_engine_perf_data(experiment_output_dir):
+def archive_query_engine_perf_data(experiment_output_dir):
     qe_profiles_dir = os.path.join(experiment_output_dir, "query_engine_profiles")
     data_files = [
         os.path.join(qe_profiles_dir, f)
@@ -220,18 +225,21 @@ def convert_query_engine_perf_data(experiment_output_dir):
         if f.startswith("perf_") and f.endswith(".data")
     ]
     for data_file in data_files:
-        script_file = data_file.replace(".data", ".script")
-        logger.debug(f"Converting {data_file} to {script_file}")
-        try:
-            with open(script_file, "w") as f:
-                subprocess.run(
-                    ["perf", "script", "-i", data_file],
-                    stdout=f,
-                    check=True,
+        archive_file = f"{data_file}.tar.bz2"
+        logger.debug(f"Archiving {data_file} to {archive_file}")
+        with tempfile.TemporaryDirectory(dir=qe_profiles_dir) as archive_dir:
+            subprocess.run(
+                ["perf", "archive", data_file],
+                cwd=archive_dir,
+                check=True,
+            )
+            generated_archive = os.path.join(archive_dir, "perf.data.tar.bz2")
+            if not os.path.isfile(generated_archive):
+                raise RuntimeError(
+                    f"perf archive did not produce expected file: {generated_archive}"
                 )
-            logger.debug(f"Finished converting {data_file}")
-        except subprocess.CalledProcessError as e:
-            logger.warning(f"perf script failed for {data_file}: {e}")
+            os.replace(generated_archive, archive_file)
+        logger.debug(f"Finished archiving {data_file}")
 
 
 # TODO Provide some way of specifying which hooks will be used
@@ -434,7 +442,7 @@ def main(args):
     if qe_flamegraph_procs:
         logger.debug("Stopping profiling for query engine pids")
         stop_profiling_query_engine_pids(qe_flamegraph_procs, store=True)
-        convert_query_engine_perf_data(args.experiment_output_dir)
+        archive_query_engine_perf_data(args.experiment_output_dir)
 
     logger.debug("Stopping process monitors")
     monitor_info = process_monitor.stop_monitor(monitor, control_pipe, monitor_pipe)

--- a/asap-tools/experiments/remote_monitor.py
+++ b/asap-tools/experiments/remote_monitor.py
@@ -5,7 +5,6 @@ import argparse
 import subprocess
 import yaml
 import signal
-import tempfile
 from loguru import logger
 
 from typing import List
@@ -217,7 +216,7 @@ def stop_profiling_query_engine_pids(qe_perf_procs, store: bool):
     logger.debug("Stopped profiling for query engine pids")
 
 
-def archive_query_engine_perf_data(experiment_output_dir):
+def convert_query_engine_perf_data(experiment_output_dir):
     qe_profiles_dir = os.path.join(experiment_output_dir, "query_engine_profiles")
     data_files = [
         os.path.join(qe_profiles_dir, f)
@@ -225,21 +224,15 @@ def archive_query_engine_perf_data(experiment_output_dir):
         if f.startswith("perf_") and f.endswith(".data")
     ]
     for data_file in data_files:
-        archive_file = f"{data_file}.tar.bz2"
-        logger.debug(f"Archiving {data_file} to {archive_file}")
-        with tempfile.TemporaryDirectory(dir=qe_profiles_dir) as archive_dir:
+        script_file = data_file.replace(".data", ".script")
+        logger.debug(f"Converting {data_file} to {script_file}")
+        with open(script_file, "w") as script_output:
             subprocess.run(
-                ["perf", "archive", data_file],
-                cwd=archive_dir,
+                ["perf", "script", "--header", "-i", data_file],
+                stdout=script_output,
                 check=True,
             )
-            generated_archive = os.path.join(archive_dir, "perf.data.tar.bz2")
-            if not os.path.isfile(generated_archive):
-                raise RuntimeError(
-                    f"perf archive did not produce expected file: {generated_archive}"
-                )
-            os.replace(generated_archive, archive_file)
-        logger.debug(f"Finished archiving {data_file}")
+        logger.debug(f"Finished converting {data_file}")
 
 
 # TODO Provide some way of specifying which hooks will be used
@@ -442,7 +435,7 @@ def main(args):
     if qe_flamegraph_procs:
         logger.debug("Stopping profiling for query engine pids")
         stop_profiling_query_engine_pids(qe_flamegraph_procs, store=True)
-        archive_query_engine_perf_data(args.experiment_output_dir)
+        convert_query_engine_perf_data(args.experiment_output_dir)
 
     logger.debug("Stopping process monitors")
     monitor_info = process_monitor.stop_monitor(monitor, control_pipe, monitor_pipe)


### PR DESCRIPTION
## Summary

- Build and launch a separate frame-pointer-enabled query engine binary for profiling runs.
- Record compact FP call chains and archive remote symbols without running perf script remotely.
- Add a local post-processing script for perf script, folded stacks, and SVG flamegraphs.
- Fail fast on the remote node when the FP binary is missing.
- Keep ClickHouse profiling aligned with the e2e workflow.

## Validation

- Python compilation passed.
- Bash syntax checks passed.
- git diff --check passed.
- Pre-commit hooks passed: shellcheck, black, flake8, and repository checks.
- FP-enabled release build passed in the profiling worktree.