### PR TITLE
fix(asap-tools): make label discovery opt-in

### DIFF
--- a/asap-planner-rs/docker-compose.yml.j2
+++ b/asap-planner-rs/docker-compose.yml.j2
@@ -15,8 +15,8 @@ services:
       "--output_dir", "/app/output",
       "--data-ingestion-interval-ms", "{{ data_ingestion_interval_ms }}",
       "--streaming_engine", "{{ streaming_engine }}",
-      "--prometheus-url", "{{ prometheus_url }}",
-      "--query-language", "{{ query_language }}"{% if punting %},
+      "--query-language", "{{ query_language }}"{% if prometheus_url %},
+      "--prometheus-url", "{{ prometheus_url }}"{% endif %}{% if punting %},
       "--enable-punting"{% endif %}
     ]
     network_mode: "host"

--- a/asap-tools/experiments/config/config.yaml
+++ b/asap-tools/experiments/config/config.yaml
@@ -99,6 +99,7 @@ query_engine:
 # Controller configuration
 controller:
   punting: ???  # REQUIRED: Enable query punting based on performance heuristics (should_be_performant check)
+  auto_discover_labels: false  # Query Prometheus for metric labels instead of using config hints
 
 # Optional manual planner windowing override. Omit this block to preserve the
 # default tumbling-window behavior. For tumbling windows, omit

--- a/asap-tools/experiments/constants.py
+++ b/asap-tools/experiments/constants.py
@@ -47,6 +47,9 @@ PROCESS_MONITOR_JOIN_TIMEOUT_SECONDS = 10
 
 PROMETHEUS_CONFIG_DIR = "prometheus_config"
 PROMETHEUS_CONFIG_FILE = "prometheus.yml"
+PROMETHEUS_REMOTE_WRITE_ENDPOINT = "/api/v1/write"
+HTTP_READINESS_CURL_TIMEOUT_SECONDS = 5
+QUERY_ENGINE_RUNTIME_INFO_ENDPOINT = "/api/v1/status/runtimeinfo"
 
 # VictoriaMetrics configuration files
 VMAGENT_SCRAPE_CONFIG_FILE = "vmagent_scrape.yml"

--- a/asap-tools/experiments/experiment_run_e2e.py
+++ b/asap-tools/experiments/experiment_run_e2e.py
@@ -321,9 +321,6 @@ def main(cfg: DictConfig):
 
         # copy_controller_client_config(args.controller_client_config, local_experiment_dir)
         if experiment_mode == constants.SKETCHDB_EXPERIMENT_NAME:
-            # The controller queries Prometheus to auto-infer metric labels, so
-            # exporters and Prometheus must be up and have at least one scrape
-            # worth of data before the controller runs.
             if config.check_exporter_and_queries_exist(
                 "fake_exporter", cfg.experiment_params
             ):
@@ -342,27 +339,34 @@ def main(cfg: DictConfig):
             # its process starts, so a fixed sleep alone can race.
             prometheus_service.wait_until_ready()
 
-            # Wait for two scrape intervals so Prometheus has series to return.
-            label_discovery_wait_ms = data_ingestion_interval_ms * 2
-            print(
-                f"Waiting {label_discovery_wait_ms / 1000}s for Prometheus to scrape initial data "
-                f"before running controller label inference..."
-            )
-            time.sleep(label_discovery_wait_ms / 1000)
+            # Config files already contain metric label hints. Only wait for
+            # scrape data when runtime label discovery has been explicitly
+            # enabled; otherwise the planner uses those hints directly.
+            discovery_backend = None
+            if args.controller_auto_discover_labels:
+                label_discovery_wait_ms = data_ingestion_interval_ms * 2
+                print(
+                    f"Waiting {label_discovery_wait_ms / 1000}s for Prometheus to scrape initial data "
+                    f"before running controller label inference..."
+                )
+                time.sleep(label_discovery_wait_ms / 1000)
+                discovery_backend = DiscoveryBackend(
+                    type="prometheus",
+                    url=f"http://localhost:{prometheus_service.get_query_endpoint_port()}",
+                    database=None,
+                )
+            else:
+                print(
+                    "Using metric labels from the controller config; "
+                    "Prometheus label discovery is disabled."
+                )
 
-            prometheus_url = (
-                f"http://localhost:{prometheus_service.get_query_endpoint_port()}"
-            )
             controller_service.start(
                 controller_input_file=controller_input_config,
                 streaming_engine=args.streaming_engine,
                 controller_remote_output_dir=CONTROLLER_REMOTE_OUTPUT_DIR,
                 punting=args.controller_punting,
-                discovery_backend=DiscoveryBackend(
-                    type="prometheus",
-                    url=prometheus_url,
-                    database=None,
-                ),
+                discovery_backend=discovery_backend,
                 data_ingestion_interval_ms=data_ingestion_interval_ms,
             )
             sync.rsync_controller_config_remote_to_local(

--- a/asap-tools/experiments/experiment_utils/config.py
+++ b/asap-tools/experiments/experiment_utils/config.py
@@ -601,6 +601,7 @@ class Args:
 
         # Controller configuration
         self.controller_punting = cfg.controller.punting
+        self.controller_auto_discover_labels = cfg.controller.auto_discover_labels
 
         # Aggregate cleanup configuration
         # Valid policies: "circular_buffer", "read_based", "no_cleanup"

--- a/asap-tools/experiments/experiment_utils/services/base.py
+++ b/asap-tools/experiments/experiment_utils/services/base.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from experiment_utils.providers.base import InfrastructureProvider
+import constants
 
 
 class BaseService(ABC):
@@ -211,7 +212,11 @@ class DockerServiceBase(BaseService):
             if self.is_healthy():
                 # Additional check - try to access service health endpoint
                 try:
-                    cmd = f"curl -s {service_url}{health_endpoint}"
+                    cmd = (
+                        f"curl -fsS --max-time "
+                        f"{constants.HTTP_READINESS_CURL_TIMEOUT_SECONDS} "
+                        f"{service_url}{health_endpoint}"
+                    )
                     result = self.provider.execute_command(
                         node_idx=self.node_offset,
                         cmd=cmd,

--- a/asap-tools/experiments/experiment_utils/services/docker_victoriametrics.py
+++ b/asap-tools/experiments/experiment_utils/services/docker_victoriametrics.py
@@ -15,12 +15,33 @@ from experiment_utils.providers.base import InfrastructureProvider
 import constants
 from constants import (
     PROMETHEUS_CONFIG_DIR,
+    PROMETHEUS_REMOTE_WRITE_ENDPOINT,
     VMAGENT_SCRAPE_CONFIG_FILE,
     VMAGENT_REMOTE_WRITE_CONFIG_FILE,
     SKETCHDB_EXPERIMENT_NAME,
     BASELINE_EXPERIMENT_NAME,
 )
 import utils
+
+
+def get_remote_write_urls(node_ip: str, experiment_mode: str):
+    """Return vmagent destinations for the selected experiment mode."""
+    vmsingle_url = f"http://{node_ip}:8428{PROMETHEUS_REMOTE_WRITE_ENDPOINT}"
+
+    if experiment_mode == BASELINE_EXPERIMENT_NAME:
+        return [vmsingle_url]
+    if experiment_mode == SKETCHDB_EXPERIMENT_NAME:
+        # vmagent is configured with forcePromProto, matching the query
+        # engine's Prometheus remote-write endpoint.
+        return [
+            vmsingle_url,
+            f"http://{node_ip}:8080{PROMETHEUS_REMOTE_WRITE_ENDPOINT}",
+        ]
+
+    raise ValueError(
+        f"Invalid experiment_mode: {experiment_mode}. Must be "
+        f"'{BASELINE_EXPERIMENT_NAME}' or '{SKETCHDB_EXPERIMENT_NAME}'"
+    )
 
 
 class DockerVictoriaMetricsService(DockerServiceBase):
@@ -135,20 +156,7 @@ class DockerVictoriaMetricsService(DockerServiceBase):
 
         # Determine remote write URLs based on experiment mode
         node_ip = self.provider.get_node_ip(self.node_offset)
-        if experiment_mode == BASELINE_EXPERIMENT_NAME:
-            # Only write to vmsingle
-            remote_write_urls = [f"http://{node_ip}:8428/api/v1/write"]
-        elif experiment_mode == SKETCHDB_EXPERIMENT_NAME:
-            # Write to both vmsingle AND queryengine
-            remote_write_urls = [
-                f"http://{node_ip}:8428/api/v1/write",
-                f"http://{node_ip}:8080/receive",
-            ]
-        else:
-            # Invalid experiment mode
-            assert (
-                False
-            ), f"Invalid experiment_mode: {experiment_mode}. Must be '{BASELINE_EXPERIMENT_NAME}' or '{SKETCHDB_EXPERIMENT_NAME}'"
+        remote_write_urls = get_remote_write_urls(node_ip, experiment_mode)
 
         # Convert resource limits to strings if specified
         if cpu_limit is not None:

--- a/asap-tools/experiments/experiment_utils/services/misc.py
+++ b/asap-tools/experiments/experiment_utils/services/misc.py
@@ -205,7 +205,7 @@ class ControllerService(BaseService):
         streaming_engine: str,
         controller_remote_output_dir: str,
         punting: bool,
-        discovery_backend: DiscoveryBackend,
+        discovery_backend: Optional[DiscoveryBackend],
         data_ingestion_interval_ms: int,
         query_language: str = "promql",
         **kwargs,
@@ -218,7 +218,8 @@ class ControllerService(BaseService):
             streaming_engine: Type of streaming engine
             controller_remote_output_dir: Controller output directory
             punting: Enable query punting based on performance heuristics
-            discovery_backend: Backend used for label/column auto-discovery.
+            discovery_backend: Optional backend used for label/column auto-discovery.
+                When omitted, the planner uses schema hints from its input config.
                 PromQL mode: DiscoveryBackend(type="prometheus", url=<url>, database=None)
                 SQL mode:    DiscoveryBackend(type="clickhouse", url=<url>, database=<db>)
             data_ingestion_interval_ms: Data ingestion interval in milliseconds (required for all modes)
@@ -246,13 +247,27 @@ class ControllerService(BaseService):
                 query_language,
             )
 
+    @staticmethod
+    def _discovery_args(discovery_backend: Optional[DiscoveryBackend]) -> str:
+        """Return planner CLI arguments for an optional discovery backend."""
+        if discovery_backend is None:
+            return ""
+        if discovery_backend.type == "prometheus":
+            return f" --prometheus-url {discovery_backend.url}"
+        if discovery_backend.type == "clickhouse":
+            args = f" --clickhouse-url {discovery_backend.url}"
+            if discovery_backend.database:
+                args += f" --clickhouse-database {discovery_backend.database}"
+            return args
+        raise ValueError(f"Unsupported discovery backend: {discovery_backend.type}")
+
     def _start_bare_metal(
         self,
         controller_input_file: str,
         streaming_engine: str,
         controller_remote_output_dir: str,
         punting: bool,
-        discovery_backend: DiscoveryBackend,
+        discovery_backend: Optional[DiscoveryBackend],
         data_ingestion_interval_ms: int,
         query_language: str,
     ) -> None:
@@ -270,12 +285,7 @@ class ControllerService(BaseService):
             f" --query-language {query_language}"
         )
         cmd += f" --data-ingestion-interval-ms {data_ingestion_interval_ms}"
-        if discovery_backend.type == "prometheus":
-            cmd += f" --prometheus-url {discovery_backend.url}"
-        elif discovery_backend.type == "clickhouse":
-            cmd += f" --clickhouse-url {discovery_backend.url}"
-            if discovery_backend.database:
-                cmd += f" --clickhouse-database {discovery_backend.database}"
+        cmd += self._discovery_args(discovery_backend)
         if punting:
             cmd += " --enable-punting"
         cmd += " -v"
@@ -296,7 +306,7 @@ class ControllerService(BaseService):
         streaming_engine: str,
         controller_remote_output_dir: str,
         punting: bool,
-        discovery_backend: DiscoveryBackend,
+        discovery_backend: Optional[DiscoveryBackend],
         data_ingestion_interval_ms: int,
         query_language: str,
     ):
@@ -327,12 +337,7 @@ class ControllerService(BaseService):
         generate_cmd += f" --streaming-engine {streaming_engine}"
         generate_cmd += f" --query-language {query_language}"
         generate_cmd += f" --data-ingestion-interval-ms {data_ingestion_interval_ms}"
-        if discovery_backend.type == "prometheus":
-            generate_cmd += f" --prometheus-url {discovery_backend.url}"
-        elif discovery_backend.type == "clickhouse":
-            generate_cmd += f" --clickhouse-url {discovery_backend.url}"
-            if discovery_backend.database:
-                generate_cmd += f" --clickhouse-database {discovery_backend.database}"
+        generate_cmd += self._discovery_args(discovery_backend)
         if punting:
             generate_cmd += " --punting"
 

--- a/asap-tools/experiments/experiment_utils/services/query_engine.py
+++ b/asap-tools/experiments/experiment_utils/services/query_engine.py
@@ -553,10 +553,10 @@ class QueryEngineRustService(BaseQueryEngineService):
 
     def is_healthy(self) -> bool:
         """
-        Check if Rust query engine is healthy by checking if process is running.
+        Check that the Rust query engine process and HTTP API are ready.
 
         Returns:
-            True if Rust query engine process is running
+            True if the process is running and its HTTP API is ready
         """
         if self.use_container:
             return self._is_healthy_containerized()
@@ -578,7 +578,7 @@ class QueryEngineRustService(BaseQueryEngineService):
             import subprocess
 
             assert isinstance(result, subprocess.CompletedProcess)
-            return result.stdout.strip() != ""
+            return result.stdout.strip() != "" and self._is_runtime_info_ready()
         except Exception:
             return False
 
@@ -595,9 +595,27 @@ class QueryEngineRustService(BaseQueryEngineService):
                 ignore_errors=True,
             )
             assert isinstance(result, subprocess.CompletedProcess)
-            return result.stdout.strip() == "true"
+            return result.stdout.strip() == "true" and self._is_runtime_info_ready()
         except Exception:
             return False
+
+    def _is_runtime_info_ready(self) -> bool:
+        """Check that the query API serves its runtime-info endpoint."""
+        cmd = (
+            f"curl -fsS --max-time {constants.HTTP_READINESS_CURL_TIMEOUT_SECONDS} "
+            f"http://127.0.0.1:{self.get_http_port()}"
+            f"{constants.QUERY_ENGINE_RUNTIME_INFO_ENDPOINT} >/dev/null"
+        )
+        result = self.provider.execute_command(
+            node_idx=self.node_offset,
+            cmd=cmd,
+            cmd_dir=None,
+            nohup=False,
+            popen=False,
+            ignore_errors=True,
+        )
+        assert isinstance(result, subprocess.CompletedProcess)
+        return result.returncode == 0
 
     def get_monitoring_keyword(self) -> str:
         """

--- a/asap-tools/experiments/generate_controller_compose.py
+++ b/asap-tools/experiments/generate_controller_compose.py
@@ -5,6 +5,7 @@ Helper script to generate docker-compose.yml for Controller from Jinja2 template
 import argparse
 import os
 import sys
+from typing import Optional
 from jinja2 import Template
 
 
@@ -18,7 +19,7 @@ def generate_compose_file(
     data_ingestion_interval_ms: int,
     streaming_engine: str,
     punting: bool,
-    prometheus_url: str,
+    prometheus_url: Optional[str],
     query_language: str,
 ):
     """Generate docker-compose.yml from template with provided variables."""
@@ -117,8 +118,8 @@ def main():
     )
     parser.add_argument(
         "--prometheus-url",
-        required=True,
-        help="Base URL of the Prometheus instance for metric label inference (e.g. http://localhost:9090)",
+        required=False,
+        help="Optional Prometheus URL for metric label inference (e.g. http://localhost:9090)",
     )
     parser.add_argument(
         "--query-language",

--- a/asap-tools/experiments/tests/test_controller_service.py
+++ b/asap-tools/experiments/tests/test_controller_service.py
@@ -1,0 +1,84 @@
+"""Tests for optional planner discovery configuration."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from experiment_utils.services.misc import ControllerService, DiscoveryBackend
+from generate_controller_compose import generate_compose_file
+
+
+class RecordingProvider:
+    def __init__(self):
+        self.commands = []
+
+    def get_home_dir(self):
+        return "/tmp"
+
+    def execute_command(self, **kwargs):
+        self.commands.append(kwargs["cmd"])
+
+
+class OptionalPlannerDiscoveryTest(unittest.TestCase):
+    def test_controller_service_omits_prometheus_url_when_discovery_disabled(self):
+        provider = RecordingProvider()
+        service = ControllerService(provider, use_container=True, node_offset=0)
+
+        service._start_containerized(
+            controller_input_file="/tmp/input.yaml",
+            streaming_engine="precompute",
+            controller_remote_output_dir="/tmp/output",
+            punting=False,
+            discovery_backend=None,
+            data_ingestion_interval_ms=1000,
+            query_language="promql",
+        )
+
+        self.assertEqual(len(provider.commands), 1)
+        self.assertNotIn("--prometheus-url", provider.commands[0])
+
+    def test_controller_service_preserves_explicit_discovery_url(self):
+        provider = RecordingProvider()
+        service = ControllerService(provider, use_container=True, node_offset=0)
+
+        service._start_containerized(
+            controller_input_file="/tmp/input.yaml",
+            streaming_engine="precompute",
+            controller_remote_output_dir="/tmp/output",
+            punting=False,
+            discovery_backend=DiscoveryBackend(
+                type="prometheus", url="http://localhost:9090", database=None
+            ),
+            data_ingestion_interval_ms=1000,
+            query_language="promql",
+        )
+
+        self.assertIn("--prometheus-url http://localhost:9090", provider.commands[0])
+
+    def test_compose_generator_omits_discovery_url_when_not_provided(self):
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "asap-planner-rs/docker-compose.yml.j2"
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "controller-compose.yml"
+            generate_compose_file(
+                template_path=str(template_path),
+                output_path=str(output_path),
+                controller_dir="/tmp/planner",
+                container_name="controller",
+                input_config_path="/tmp/input.yaml",
+                output_dir="/tmp/output",
+                data_ingestion_interval_ms=1000,
+                streaming_engine="precompute",
+                punting=False,
+                prometheus_url=None,
+                query_language="promql",
+            )
+            compose = output_path.read_text()
+
+        self.assertNotIn("--prometheus-url", compose)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/asap-tools/experiments/tests/test_victoriametrics_readiness.py
+++ b/asap-tools/experiments/tests/test_victoriametrics_readiness.py
@@ -1,0 +1,89 @@
+"""Regression tests for VictoriaMetrics and query-engine readiness."""
+
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+from constants import BASELINE_EXPERIMENT_NAME, SKETCHDB_EXPERIMENT_NAME
+from experiment_utils.services.base import DockerServiceBase
+from experiment_utils.services.docker_victoriametrics import get_remote_write_urls
+from experiment_utils.services.query_engine import QueryEngineRustService
+
+
+class RemoteWriteConfigurationTest(unittest.TestCase):
+    def test_sketchdb_uses_prometheus_remote_write_endpoint(self):
+        self.assertEqual(
+            get_remote_write_urls("10.10.1.1", SKETCHDB_EXPERIMENT_NAME),
+            [
+                "http://10.10.1.1:8428/api/v1/write",
+                "http://10.10.1.1:8080/api/v1/write",
+            ],
+        )
+
+    def test_baseline_only_writes_to_vmsingle(self):
+        self.assertEqual(
+            get_remote_write_urls("10.10.1.1", BASELINE_EXPERIMENT_NAME),
+            ["http://10.10.1.1:8428/api/v1/write"],
+        )
+
+    def test_unknown_experiment_mode_fails_loudly(self):
+        with self.assertRaises(ValueError):
+            get_remote_write_urls("10.10.1.1", "unknown")
+
+
+class FakeDockerService(DockerServiceBase):
+    def start(self, **kwargs):
+        pass
+
+    def stop(self, **kwargs):
+        pass
+
+    def get_container_name(self):
+        return "fake"
+
+    def get_service_url(self):
+        return "http://localhost:8428"
+
+    def get_health_endpoint(self):
+        return "/health"
+
+    def is_healthy(self):
+        return True
+
+
+class ReadinessCheckTest(unittest.TestCase):
+    def test_http_400_is_not_considered_ready(self):
+        provider = Mock()
+        provider.execute_command.return_value = subprocess.CompletedProcess(
+            args="curl", returncode=22, stdout="", stderr=""
+        )
+        service = FakeDockerService(provider, num_nodes=1, node_offset=0)
+
+        with patch("experiment_utils.services.base.time.sleep"):
+            with self.assertRaises(RuntimeError):
+                service._wait_for_service_ready(max_retries=1)
+
+        command = provider.execute_command.call_args.kwargs["cmd"]
+        self.assertIn("curl -fsS", command)
+
+    def test_query_engine_requires_runtime_info_endpoint(self):
+        provider = Mock()
+        provider.execute_command.side_effect = [
+            subprocess.CompletedProcess(
+                args="docker inspect", returncode=0, stdout="true\n", stderr=""
+            ),
+            subprocess.CompletedProcess(
+                args="curl", returncode=22, stdout="", stderr=""
+            ),
+        ]
+        service = QueryEngineRustService(provider, use_container=True, node_offset=0)
+
+        self.assertFalse(service.is_healthy())
+        self.assertIn(
+            "/api/v1/status/runtimeinfo",
+            provider.execute_command.call_args_list[1].kwargs["cmd"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Make controller label discovery opt-in via `controller.auto_discover_labels` (default: false).
- Use the controller config's metric-label hints by default, avoiding high-cardinality `/api/v1/series` requests.
- Preserve explicit Prometheus/ClickHouse discovery support and omit the CLI flags when no discovery backend is configured.

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py'` (4 passed)
- Python compilation passed.
- Pre-commit hooks passed.
