### PR TITLE
feat(planner): infer label groups from series dataset

### DIFF
--- a/.design_docs/optimizer-v1-implementation-plan.md
+++ b/.design_docs/optimizer-v1-implementation-plan.md
@@ -76,6 +76,7 @@ asap-planner-rs/src/optimizer/
 ├── translator.rs          translate(&OptimizerSolution) → (StreamingConfig, InferenceConfig)
 ├── aqe_extractor.rs       Rqe, extract_aqes()
 ├── pipeline.rs            run_all_exact_pipeline(), run_greedy_pipeline()
+├── dataset.rs             CSV series inventory, schema validation, and N_g profiling [#693]
 ├── sketch_properties.rs   algebraic properties per AggregationType    [Phase 2a, done]
 ├── candidate_gen.rs       enumerate candidate configs per AQE         [Phase 2b, done]
 ├── cost_model.rs          ingest/query cost formulas                  [Phase 2c, done]
@@ -150,6 +151,7 @@ pub struct CandidateConfig {
     pub config: Option<AggregationConfig>,  // None = EXACT fallback
     pub query_method: QueryMethod,
     pub n_windows: u64,
+    pub label_group_count: u64,             // dataset-derived N_g
 }
 pub fn enumerate_candidates(aqe: &Aqe, scrape_interval_secs: u64) -> Vec<CandidateConfig>
 ```
@@ -182,8 +184,10 @@ pub fn query_cost(a: &Aqe, candidate: &CandidateConfig, costs: &AtomicCosts, wei
 pub fn total_cost_rate(a: &Aqe, candidate: &CandidateConfig, rho_g: f64, costs: &AtomicCosts, weights: &CostWeights) -> f64
 ```
 
-Implements the design doc's formulas with `N(s,g) = 1` hardcoded everywhere (real `N_g` —
-distinct label-group count — needs Prometheus series-count profiling, not wired up; Phase 3).
+Implements the design doc's formulas with `N(s,g) = 1` for subpopulation-aware sketches and
+the dataset-derived `N_g` for per-label-group sketches. The CSV series inventory and exact
+filter profiling are implemented in `dataset.rs` (#693); Prometheus-backed profiling remains
+the follow-up in #525.
 `AtomicCosts` added `exact_query_cpu_secs` (not in the original plan) — without a non-zero cost
 for the EXACT fallback's query, `IngestCost=0, QueryCost=0` would make EXACT always win trivially.
 
@@ -216,9 +220,10 @@ For each AQE independently: `argmin` over `enumerate_candidates(aqe, ...)` by `t
 No feasibility filter needed (see 2d note) — every candidate from `enumerate_candidates` is valid
 for that AQE by construction. Assigns sequential `aggregation_id`s to deployed configs.
 
-`run_greedy_pipeline(config, schema, scrape_interval_secs, rho_g) -> (StreamingConfig, InferenceConfig)`
-added to `pipeline.rs` alongside `run_all_exact_pipeline()`. `rho_g` is currently a single
-placeholder value applied uniformly to every candidate — see open TODO below.
+`run_greedy_pipeline(config, dataset, scrape_interval_secs, rho_g) -> Result<(StreamingConfig, InferenceConfig), DatasetError>`
+added to `pipeline.rs` alongside `run_all_exact_pipeline()`. The dataset is required for the
+greedy path and supplies metric schemas plus the `N_g` profile for each AQE. `rho_g` is
+currently a single placeholder value applied uniformly to every candidate — see open TODO below.
 
 `translator.rs::build_inference_config()` now populates `query_configs`: for each assignment with
 a real `aggregation_id`, emits one `QueryConfig` per original query string, with
@@ -314,13 +319,17 @@ standalone `asap-optimizer-cli` binary (`asap-planner-rs/src/bin/optimizer_cli.r
 ```
 cargo run -p asap_planner --bin asap-optimizer-cli -- \
   --input_config <path/to/workload.yaml> \
+  --dataset <path/to/series-inventory.csv> \
   --data-ingestion-interval-ms 60000 \
   [--rho 1.0] \
   [--atomic-costs <path/to/atomic_costs.json>]
 ```
 
-Takes the same `ControllerConfig` YAML format as `asap-planner --input_config`
-(with a `metrics:` hints block for label schema — no live Prometheus needed).
+Takes the same `ControllerConfig` YAML format as `asap-planner --input_config`.
+The required CSV dataset is one row per unique metric series, with a fixed `metric`
+column and label columns. It derives the metric schema and each AQE's distinct
+group count; no live Prometheus connection is needed. A `metrics:` hints block, when
+present, is checked against the dataset and mismatches fail loudly.
 Prints deployed streaming configs and query configs to stdout. `--rho` is the
 placeholder arrival rate (see TODOs below — not real yet). `--atomic-costs` is
 optional; omit it and every candidate costs at the flat stub, same as before #549.
@@ -340,13 +349,14 @@ optional; omit it and every candidate costs at the flat stub, same as before #54
 
 ```
 # See what each candidate would cost, before selection:
-cargo run -p asap_planner --bin candidate-gen-dump -- \
+ cargo run -p asap_planner --bin candidate-gen-dump -- \
   --input_config workload.yaml --data-ingestion-interval-ms 60000 \
   --atomic-costs path/to/atomic_costs.json
 
 # Run the actual optimizer:
 cargo run -p asap_planner --bin asap-optimizer-cli -- \
   --input_config workload.yaml --data-ingestion-interval-ms 60000 \
+  --dataset path/to/series-inventory.csv \
   --atomic-costs path/to/atomic_costs.json
 ```
 
@@ -366,7 +376,7 @@ instead of `generator::generate_plan()`, likely behind an opt-in flag first.
 |---|---|---|
 | `aqe_extractor.rs` | `extract_requirements()` | Duplicates `build_query_requirements_promql` in `asap-query-engine/src/engines/simple_engine/promql.rs:614` — extract to shared free fn in `asap_types::query_requirements` |
 | `capability_matching.rs` | `labels_compatible()`, line 86 | Relax to superset matching — do in Phase 3b |
-| `cost_model.rs` | `ingest_cost()`, `query_cost()` | `N(s,g)` hardcoded to `1` everywhere; real `N_g` (distinct label-group count) needs Prometheus series-count profiling |
+| `cost_model.rs` | `ingest_cost()`, `query_cost()` | Prometheus-backed `N_g` profiling remains for #525; dataset-backed `N_g` is implemented in #693 |
 | `cost_model.rs` | `CostWeights::default()` | Self-consistent stub ratio (mem:cpu ≈ 1e-9:1), not real $/byte-sec vs $/cpu-sec calibration |
 | `greedy.rs`, `pipeline.rs` | `rho_g` parameter | Single placeholder value applied uniformly; real per-config rates need Prometheus scrape-rate × active-series-count, not wired up |
 | `translator.rs` | `retention_count_for_assignment(Subtract)` | Returns hardcoded `1`; should be the actual checkpoint count needed to cover the full lookback |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "asap_types",
  "chrono",
  "clap 4.6.1",
+ "csv",
  "elastic_dsl_utilities",
  "indexmap 2.14.0",
  "pretty_assertions",

--- a/asap-planner-rs/Cargo.toml
+++ b/asap-planner-rs/Cargo.toml
@@ -37,6 +37,7 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
+csv = "1.4.0"
 indexmap.workspace = true
 chrono.workspace = true
 promql-parser = "0.5.0"

--- a/asap-planner-rs/src/bin/optimizer_cli.rs
+++ b/asap-planner-rs/src/bin/optimizer_cli.rs
@@ -6,7 +6,9 @@
 
 use std::path::PathBuf;
 
-use asap_planner::optimizer::{load_atomic_cost_table, run_greedy_pipeline, AtomicCostTable};
+use asap_planner::optimizer::{
+    load_atomic_cost_table, run_greedy_pipeline, AtomicCostTable, SeriesDataset,
+};
 use asap_planner::ControllerConfig;
 use clap::Parser;
 
@@ -22,6 +24,10 @@ struct Args {
 
     #[arg(long = "data-ingestion-interval-ms")]
     data_ingestion_interval_ms: u64,
+
+    /// CSV series inventory used to derive metric schemas and label-group counts.
+    #[arg(long = "dataset")]
+    dataset: PathBuf,
 
     /// Placeholder arrival rate (items/sec) applied uniformly to every candidate's
     /// IngestCost. Real per-config rates aren't wired up yet — see the open TODOs
@@ -62,7 +68,7 @@ fn main() -> anyhow::Result<()> {
 
     let yaml_str = std::fs::read_to_string(&args.input_config)?;
     let config: ControllerConfig = serde_yaml::from_str(&yaml_str)?;
-    let schema = config.schema_from_hints();
+    let dataset = SeriesDataset::from_path(&args.dataset)?;
 
     let atomic_cost_table = match &args.atomic_costs {
         Some(path) => load_atomic_cost_table(path)?,
@@ -76,11 +82,11 @@ fn main() -> anyhow::Result<()> {
 
     let (streaming, inference) = run_greedy_pipeline(
         &config,
-        &schema,
+        &dataset,
         args.data_ingestion_interval_ms,
         args.rho,
         &atomic_cost_table,
-    );
+    )?;
 
     let deployed = streaming.get_all_aggregation_configs();
     println!("=== Deployed streaming configs: {} ===", deployed.len());

--- a/asap-planner-rs/src/optimizer/candidate_gen.rs
+++ b/asap-planner-rs/src/optimizer/candidate_gen.rs
@@ -22,6 +22,9 @@ pub struct CandidateConfig {
     pub query_method: QueryMethod,
     /// Number of retained windows used at query time (n for Merge, 1 for Direct/Subtract, 0 for Exact).
     pub n_windows: u64,
+    /// Number of distinct label groups represented by this candidate.
+    /// Subpopulation-aware sketches ignore this value during cost evaluation.
+    pub label_group_count: u64,
 }
 
 /// Enumerate all candidate configs for an AQE.
@@ -32,11 +35,24 @@ pub struct CandidateConfig {
 /// Multi-statistic AQEs (e.g. avg = [Sum, Count]) return only EXACT — a single
 /// sketch family cannot serve two incompatible statistics simultaneously.
 pub fn enumerate_candidates(aqe: &AQE, scrape_interval_ms: u64) -> Vec<CandidateConfig> {
+    enumerate_candidates_with_label_group_count(aqe, scrape_interval_ms, 1)
+}
+
+/// Enumerate candidates with a dataset-derived label-group count.
+pub fn enumerate_candidates_with_label_group_count(
+    aqe: &AQE,
+    scrape_interval_ms: u64,
+    label_group_count: u64,
+) -> Vec<CandidateConfig> {
+    assert!(
+        label_group_count > 0,
+        "label_group_count must be greater than zero"
+    );
     let mut candidates = Vec::new();
 
     if aqe.requirements.statistics.len() != 1 {
         // ponytail: multi-stat AQEs (avg) need two sketches; not supported in v1.
-        candidates.push(exact_candidate());
+        candidates.push(exact_candidate(label_group_count));
         return candidates;
     }
 
@@ -77,20 +93,22 @@ pub fn enumerate_candidates(aqe: &AQE, scrape_interval_ms: u64) -> Vec<Candidate
                     config: Some(config),
                     query_method: qm,
                     n_windows: n,
+                    label_group_count,
                 });
             }
         }
     }
 
-    candidates.push(exact_candidate());
+    candidates.push(exact_candidate(label_group_count));
     candidates
 }
 
-fn exact_candidate() -> CandidateConfig {
+fn exact_candidate(label_group_count: u64) -> CandidateConfig {
     CandidateConfig {
         config: None,
         query_method: QueryMethod::Exact,
         n_windows: 0,
+        label_group_count,
     }
 }
 
@@ -343,6 +361,17 @@ mod tests {
         assert!(candidates
             .iter()
             .any(|c| c.config.is_none() && c.query_method == QueryMethod::Exact));
+    }
+
+    #[test]
+    fn stamps_dataset_label_group_count_on_every_candidate() {
+        let aqe = make_aqe(Statistic::Sum, 300_000, 60_000);
+        let candidates = enumerate_candidates_with_label_group_count(&aqe, 15_000, 7);
+
+        assert!(!candidates.is_empty());
+        assert!(candidates
+            .iter()
+            .all(|candidate| candidate.label_group_count == 7));
     }
 
     #[test]

--- a/asap-planner-rs/src/optimizer/cost_model.rs
+++ b/asap-planner-rs/src/optimizer/cost_model.rs
@@ -1,4 +1,5 @@
 use asap_types::enums::WindowType;
+use promql_utilities::query_logics::enums::AggregationType;
 
 use super::candidate_gen::CandidateConfig;
 use super::constants::{
@@ -75,7 +76,7 @@ pub fn ingest_cost(
         return 0.0; // EXACT: no streaming config deployed.
     };
 
-    let subpopulation_count = SUBPOPULATION_COUNT;
+    let subpopulation_count = effective_subpopulation_count(candidate, agg_config.aggregation_type);
 
     // Defensive floor: slide_interval_ms is a plain u64 on a widely-shared struct;
     // guard against div-by-zero producing `inf` and poisoning cost comparisons.
@@ -108,7 +109,7 @@ pub fn query_cost(
     };
 
     // Subpopulation count; see ingest_cost comment.
-    let subpopulation_count = SUBPOPULATION_COUNT;
+    let subpopulation_count = effective_subpopulation_count(candidate, agg_config.aggregation_type);
     let props = sketch_properties(agg_config.aggregation_type);
 
     let (cpu, mem) = match &candidate.query_method {
@@ -139,6 +140,21 @@ pub fn query_cost(
     };
 
     weights.query_cpu * cpu + weights.query_mem * mem
+}
+
+fn effective_subpopulation_count(
+    candidate: &CandidateConfig,
+    aggregation_type: AggregationType,
+) -> f64 {
+    if sketch_properties(aggregation_type).subpopulation_aware {
+        SUBPOPULATION_COUNT
+    } else {
+        assert!(
+            candidate.label_group_count > 0,
+            "non-subpopulation-aware candidates require a positive label_group_count"
+        );
+        candidate.label_group_count as f64
+    }
 }
 
 /// Total cost rate contributed by assigning AQE `aqe` (with frequency
@@ -186,6 +202,7 @@ mod tests {
             config: None,
             query_method: QueryMethod::Exact,
             n_windows: 0,
+            label_group_count: 1,
         };
         let costs = AtomicCosts::default();
         let weights = CostWeights::default();
@@ -211,11 +228,13 @@ mod tests {
             config: Some(template.clone()),
             query_method: QueryMethod::Merge { num_windows: 2 },
             n_windows: 2,
+            label_group_count: 1,
         };
         let c5 = CandidateConfig {
             config: Some(template),
             query_method: QueryMethod::Merge { num_windows: 5 },
             n_windows: 5,
+            label_group_count: 1,
         };
 
         assert_eq!(
@@ -242,15 +261,86 @@ mod tests {
             config: Some(template.clone()),
             query_method: QueryMethod::Merge { num_windows: 5 },
             n_windows: 5,
+            label_group_count: 1,
         };
         let subtract = CandidateConfig {
             config: Some(template),
             query_method: QueryMethod::Subtract,
             n_windows: 5,
+            label_group_count: 1,
         };
 
         assert!(
             query_cost(&a, &subtract, &costs, &weights) < query_cost(&a, &merge, &costs, &weights)
+        );
+    }
+
+    #[test]
+    fn non_subpopulation_aware_cost_scales_with_label_group_count() {
+        let a = make_aqe(Statistic::Sum, 300_000, 300_000);
+        let candidate = enumerate_candidates(&a, 60_000)
+            .into_iter()
+            .find(|candidate| {
+                candidate.config.as_ref().is_some_and(|config| {
+                    !sketch_properties(config.aggregation_type).subpopulation_aware
+                })
+            })
+            .expect("expected a non-subpopulation-aware candidate");
+        let one_group = CandidateConfig {
+            label_group_count: 1,
+            ..candidate.clone()
+        };
+        let five_groups = CandidateConfig {
+            label_group_count: 5,
+            ..candidate
+        };
+        let costs = AtomicCosts::default();
+        let weights = CostWeights {
+            ingest_mem: 1.0,
+            ingest_cpu: 0.0,
+            query_mem: 1.0,
+            query_cpu: 0.0,
+        };
+
+        assert_eq!(
+            ingest_cost(&five_groups, 1.0, &costs, &weights),
+            5.0 * ingest_cost(&one_group, 1.0, &costs, &weights)
+        );
+        assert_eq!(
+            query_cost(&a, &five_groups, &costs, &weights),
+            5.0 * query_cost(&a, &one_group, &costs, &weights)
+        );
+    }
+
+    #[test]
+    fn subpopulation_aware_cost_ignores_label_group_count() {
+        let a = make_aqe(Statistic::Sum, 300_000, 300_000);
+        let candidate = enumerate_candidates(&a, 60_000)
+            .into_iter()
+            .find(|candidate| {
+                candidate.config.as_ref().is_some_and(|config| {
+                    sketch_properties(config.aggregation_type).subpopulation_aware
+                })
+            })
+            .expect("expected a subpopulation-aware candidate");
+        let one_group = CandidateConfig {
+            label_group_count: 1,
+            ..candidate.clone()
+        };
+        let five_groups = CandidateConfig {
+            label_group_count: 5,
+            ..candidate
+        };
+        let costs = AtomicCosts::default();
+        let weights = CostWeights::default();
+
+        assert_eq!(
+            ingest_cost(&one_group, 1.0, &costs, &weights),
+            ingest_cost(&five_groups, 1.0, &costs, &weights)
+        );
+        assert_eq!(
+            query_cost(&a, &one_group, &costs, &weights),
+            query_cost(&a, &five_groups, &costs, &weights)
         );
     }
 }

--- a/asap-planner-rs/src/optimizer/dataset.rs
+++ b/asap-planner-rs/src/optimizer/dataset.rs
@@ -1,0 +1,598 @@
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use asap_types::query_requirements::QueryRequirements;
+use asap_types::PromQLSchema;
+use csv::StringRecord;
+use promql_parser::label::MatchOp;
+use promql_parser::parser::{self, Expr};
+use promql_utilities::data_model::KeyByLabelNames;
+use thiserror::Error;
+
+use crate::config::input::MetricDefinition;
+
+use super::solution::AQE;
+
+const METRIC_COLUMN: &str = "metric";
+
+#[derive(Debug, Error)]
+pub enum DatasetError {
+    #[error("failed to open dataset '{path}': {source}")]
+    Open {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse dataset CSV: {0}")]
+    Csv(#[from] csv::Error),
+    #[error("dataset must contain a column named 'metric'")]
+    MissingMetricColumn,
+    #[error("dataset header contains duplicate column '{0}'")]
+    DuplicateColumn(String),
+    #[error("dataset header contains an empty column name")]
+    EmptyColumn,
+    #[error("dataset contains no series rows")]
+    Empty,
+    #[error("dataset row {row} has an empty metric name")]
+    EmptyMetric { row: usize },
+    #[error(
+        "metric '{metric}' has inconsistent label columns at row {row}: expected {expected:?}, found {found:?}"
+    )]
+    InconsistentMetricSchema {
+        metric: String,
+        row: usize,
+        expected: Vec<String>,
+        found: Vec<String>,
+    },
+    #[error(
+        "metric '{metric}' has duplicate series at row {row}; first occurrence was row {first_row}"
+    )]
+    DuplicateSeries {
+        metric: String,
+        row: usize,
+        first_row: usize,
+    },
+    #[error("dataset label column '{0}' is not used by any metric")]
+    UnusedColumn(String),
+    #[error("dataset is missing workload metric '{0}'")]
+    MissingMetric(String),
+    #[error("dataset contains metric '{0}', which is not referenced by the workload")]
+    ExtraMetric(String),
+    #[error("metric '{metric}' has no label column '{label}'")]
+    MissingLabel { metric: String, label: String },
+    #[error("metric hint '{metric}' is not present in the dataset")]
+    ExtraMetricHint { metric: String },
+    #[error(
+        "metric '{metric}' label hint does not match the dataset: hint={hint:?}, dataset={dataset:?}"
+    )]
+    MetricHintMismatch {
+        metric: String,
+        hint: Vec<String>,
+        dataset: Vec<String>,
+    },
+    #[error("invalid spatial filter '{filter}': {reason}")]
+    InvalidFilter { filter: String, reason: String },
+    #[error("spatial filter '{filter}' uses unsupported matcher '{matcher}'")]
+    UnsupportedFilter { filter: String, matcher: String },
+    #[error("spatial filter '{filter}' repeats label '{label}'")]
+    DuplicateFilterLabel { filter: String, label: String },
+    #[error("metric '{metric}' has no series matching filter '{filter}'")]
+    NoMatchingSeries { metric: String, filter: String },
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ProfileKey {
+    pub metric: String,
+    pub spatial_filter_normalized: String,
+    pub grouping_labels: KeyByLabelNames,
+}
+
+impl ProfileKey {
+    pub fn from_requirements(requirements: &QueryRequirements) -> Self {
+        Self {
+            metric: requirements.metric.clone(),
+            spatial_filter_normalized: requirements.spatial_filter_normalized.clone(),
+            grouping_labels: requirements.grouping_labels.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MetricData {
+    label_names: KeyByLabelNames,
+    series: Vec<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SeriesDataset {
+    metrics: HashMap<String, MetricData>,
+}
+
+impl SeriesDataset {
+    pub fn from_path(path: &Path) -> Result<Self, DatasetError> {
+        let file = File::open(path).map_err(|source| DatasetError::Open {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::from_reader(file)
+    }
+
+    pub fn from_reader<R: Read>(reader: R) -> Result<Self, DatasetError> {
+        let mut csv_reader = csv::Reader::from_reader(reader);
+        let headers = csv_reader.headers()?.clone();
+        let header_names = validate_headers(&headers)?;
+        let metric_index = header_names
+            .iter()
+            .position(|name| name == METRIC_COLUMN)
+            .ok_or(DatasetError::MissingMetricColumn)?;
+
+        let mut raw_rows = Vec::new();
+        for (index, record) in csv_reader.records().enumerate() {
+            let row_number = index + 2;
+            let record = record?;
+            let metric = record.get(metric_index).unwrap_or_default().to_string();
+            if metric.is_empty() {
+                return Err(DatasetError::EmptyMetric { row: row_number });
+            }
+
+            let values = header_names
+                .iter()
+                .enumerate()
+                .filter_map(|(column_index, column_name)| {
+                    if column_index == metric_index {
+                        return None;
+                    }
+                    let value = record.get(column_index).unwrap_or_default();
+                    (!value.is_empty()).then(|| (column_name.clone(), value.to_string()))
+                })
+                .collect();
+
+            raw_rows.push(RawRow {
+                row_number,
+                metric,
+                values,
+            });
+        }
+
+        if raw_rows.is_empty() {
+            return Err(DatasetError::Empty);
+        }
+
+        let mut rows_by_metric: HashMap<String, Vec<RawRow>> = HashMap::new();
+        for row in raw_rows {
+            rows_by_metric
+                .entry(row.metric.clone())
+                .or_default()
+                .push(row);
+        }
+
+        let mut metrics = HashMap::new();
+        let mut used_columns = HashSet::new();
+        for (metric, rows) in rows_by_metric {
+            let expected = sorted_keys(&rows[0].values);
+            let mut seen_series: HashMap<Vec<String>, usize> = HashMap::new();
+            let mut series = Vec::with_capacity(rows.len());
+
+            for row in rows {
+                let found = sorted_keys(&row.values);
+                if found != expected {
+                    return Err(DatasetError::InconsistentMetricSchema {
+                        metric: metric.clone(),
+                        row: row.row_number,
+                        expected: expected.clone(),
+                        found,
+                    });
+                }
+
+                let key: Vec<String> = expected
+                    .iter()
+                    .map(|label| row.values[label].clone())
+                    .collect();
+                if let Some(first_row) = seen_series.insert(key, row.row_number) {
+                    return Err(DatasetError::DuplicateSeries {
+                        metric: metric.clone(),
+                        row: row.row_number,
+                        first_row,
+                    });
+                }
+
+                used_columns.extend(expected.iter().cloned());
+                series.push(row.values);
+            }
+
+            metrics.insert(
+                metric,
+                MetricData {
+                    label_names: KeyByLabelNames::new(expected),
+                    series,
+                },
+            );
+        }
+
+        for column in header_names {
+            if column != METRIC_COLUMN && !used_columns.contains(&column) {
+                return Err(DatasetError::UnusedColumn(column));
+            }
+        }
+
+        Ok(Self { metrics })
+    }
+
+    pub fn schema(&self) -> PromQLSchema {
+        let mut schema = PromQLSchema::new();
+        for (metric, data) in &self.metrics {
+            schema = schema.add_metric(metric.clone(), data.label_names.clone());
+        }
+        schema
+    }
+
+    pub fn validate_metric_hints(
+        &self,
+        hints: Option<&[MetricDefinition]>,
+    ) -> Result<(), DatasetError> {
+        let Some(hints) = hints else {
+            return Ok(());
+        };
+
+        for hint in hints {
+            let Some(data) = self.metrics.get(&hint.metric) else {
+                return Err(DatasetError::ExtraMetricHint {
+                    metric: hint.metric.clone(),
+                });
+            };
+            let hint_labels = KeyByLabelNames::new(hint.labels.clone()).labels;
+            if hint_labels != data.label_names.labels {
+                return Err(DatasetError::MetricHintMismatch {
+                    metric: hint.metric.clone(),
+                    hint: hint_labels,
+                    dataset: data.label_names.labels.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn profile_aqes(&self, aqes: &[AQE]) -> Result<HashMap<ProfileKey, u64>, DatasetError> {
+        let workload_metrics: HashSet<&str> = aqes
+            .iter()
+            .map(|aqe| aqe.requirements.metric.as_str())
+            .collect();
+
+        for metric in &workload_metrics {
+            if !self.metrics.contains_key(*metric) {
+                return Err(DatasetError::MissingMetric((*metric).to_string()));
+            }
+        }
+        for metric in self.metrics.keys() {
+            if !workload_metrics.contains(metric.as_str()) {
+                return Err(DatasetError::ExtraMetric(metric.clone()));
+            }
+        }
+
+        let mut profiles = HashMap::new();
+        for aqe in aqes {
+            let key = ProfileKey::from_requirements(&aqe.requirements);
+            if let Entry::Vacant(entry) = profiles.entry(key) {
+                entry.insert(self.profile(&aqe.requirements)?);
+            }
+        }
+        Ok(profiles)
+    }
+
+    pub fn profile(&self, requirements: &QueryRequirements) -> Result<u64, DatasetError> {
+        let data = self
+            .metrics
+            .get(&requirements.metric)
+            .ok_or_else(|| DatasetError::MissingMetric(requirements.metric.clone()))?;
+
+        for label in &requirements.grouping_labels.labels {
+            if !data.label_names.labels.contains(label) {
+                return Err(DatasetError::MissingLabel {
+                    metric: requirements.metric.clone(),
+                    label: label.clone(),
+                });
+            }
+        }
+
+        let matchers = parse_exact_filter(
+            &requirements.metric,
+            &requirements.spatial_filter_normalized,
+        )?;
+        for (label, _) in &matchers {
+            if !data.label_names.labels.contains(label) {
+                return Err(DatasetError::MissingLabel {
+                    metric: requirements.metric.clone(),
+                    label: label.clone(),
+                });
+            }
+        }
+
+        let matching_series: Vec<&HashMap<String, String>> = data
+            .series
+            .iter()
+            .filter(|series| {
+                matchers
+                    .iter()
+                    .all(|(label, value)| series.get(label).is_some_and(|actual| actual == value))
+            })
+            .collect();
+
+        if matching_series.is_empty() {
+            return Err(DatasetError::NoMatchingSeries {
+                metric: requirements.metric.clone(),
+                filter: requirements.spatial_filter_normalized.clone(),
+            });
+        }
+
+        if requirements.grouping_labels.is_empty() {
+            return Ok(1);
+        }
+
+        let groups: HashSet<Vec<&str>> = matching_series
+            .iter()
+            .map(|series| {
+                requirements
+                    .grouping_labels
+                    .labels
+                    .iter()
+                    .map(|label| series[label].as_str())
+                    .collect()
+            })
+            .collect();
+        Ok(groups.len() as u64)
+    }
+}
+
+#[derive(Debug)]
+struct RawRow {
+    row_number: usize,
+    metric: String,
+    values: HashMap<String, String>,
+}
+
+fn validate_headers(headers: &StringRecord) -> Result<Vec<String>, DatasetError> {
+    let mut seen = HashSet::new();
+    let mut names = Vec::with_capacity(headers.len());
+    for name in headers {
+        if name.is_empty() {
+            return Err(DatasetError::EmptyColumn);
+        }
+        if !seen.insert(name.to_string()) {
+            return Err(DatasetError::DuplicateColumn(name.to_string()));
+        }
+        names.push(name.to_string());
+    }
+    Ok(names)
+}
+
+fn sorted_keys(values: &HashMap<String, String>) -> Vec<String> {
+    let mut keys: Vec<String> = values.keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+fn parse_exact_filter(metric: &str, filter: &str) -> Result<Vec<(String, String)>, DatasetError> {
+    if filter.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let selector = format!("{metric}{filter}");
+    let expression = parser::parse(&selector).map_err(|error| DatasetError::InvalidFilter {
+        filter: filter.to_string(),
+        reason: error.to_string(),
+    })?;
+    let Expr::VectorSelector(vector) = expression else {
+        return Err(DatasetError::InvalidFilter {
+            filter: filter.to_string(),
+            reason: "expected a vector selector".to_string(),
+        });
+    };
+
+    if !vector.matchers.or_matchers.is_empty() {
+        return Err(DatasetError::UnsupportedFilter {
+            filter: filter.to_string(),
+            matcher: "or".to_string(),
+        });
+    }
+
+    let mut seen_labels = HashSet::new();
+    let mut matchers = Vec::with_capacity(vector.matchers.matchers.len());
+    for matcher in vector.matchers.matchers {
+        if !matches!(&matcher.op, MatchOp::Equal) {
+            return Err(DatasetError::UnsupportedFilter {
+                filter: filter.to_string(),
+                matcher: matcher.op.to_string(),
+            });
+        }
+        if !seen_labels.insert(matcher.name.clone()) {
+            return Err(DatasetError::DuplicateFilterLabel {
+                filter: filter.to_string(),
+                label: matcher.name,
+            });
+        }
+        matchers.push((matcher.name, matcher.value));
+    }
+    Ok(matchers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use asap_types::query_requirements::QueryRequirements;
+    use promql_utilities::data_model::KeyByLabelNames;
+
+    fn requirements(metric: &str, labels: &[&str], filter: &str) -> QueryRequirements {
+        QueryRequirements {
+            metric: metric.to_string(),
+            statistics: vec![],
+            data_range_ms: 1,
+            grouping_labels: KeyByLabelNames::new(
+                labels.iter().map(|label| (*label).to_string()).collect(),
+            ),
+            spatial_filter_normalized: filter.to_string(),
+            topk_count_events: None,
+        }
+    }
+
+    #[test]
+    fn derives_metric_schema_and_counts_distinct_group_values() {
+        let dataset = SeriesDataset::from_reader(
+            "metric,job,instance,region\nrequests,api,a,us\nrequests,api,b,us\nrequests,worker,c,us\n"
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dataset.schema().get_labels("requests").unwrap().labels,
+            vec!["instance", "job", "region"]
+        );
+        assert_eq!(
+            dataset
+                .profile(&requirements("requests", &["job"], ""))
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            dataset
+                .profile(&requirements("requests", &["instance"], ""))
+                .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn applies_multiple_exact_filters() {
+        let dataset = SeriesDataset::from_reader(
+            "metric,job,instance\nrequests,api,a\nrequests,api,b\nrequests,worker,c\n".as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dataset
+                .profile(&requirements(
+                    "requests",
+                    &["instance"],
+                    "{job=\"api\",instance=\"b\"}"
+                ))
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn empty_grouping_is_one_but_empty_filter_result_fails() {
+        let dataset =
+            SeriesDataset::from_reader("metric,job\nrequests,api\nrequests,worker\n".as_bytes())
+                .unwrap();
+
+        assert_eq!(
+            dataset.profile(&requirements("requests", &[], "")).unwrap(),
+            1
+        );
+        assert!(matches!(
+            dataset.profile(&requirements("requests", &[], "{job=\"missing\"}")),
+            Err(DatasetError::NoMatchingSeries { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_series() {
+        let error = SeriesDataset::from_reader(
+            "metric,job,instance\nrequests,api,a\nrequests,api,a\n".as_bytes(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, DatasetError::DuplicateSeries { .. }));
+    }
+
+    #[test]
+    fn rejects_schema_changes_within_a_metric() {
+        let error = SeriesDataset::from_reader(
+            "metric,job,instance\nrequests,api,a\nrequests,api,\n".as_bytes(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DatasetError::InconsistentMetricSchema { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_non_exact_filters() {
+        let dataset = SeriesDataset::from_reader("metric,job\nrequests,api\n".as_bytes()).unwrap();
+
+        let error = dataset
+            .profile(&requirements("requests", &[], "{job=~\"api\"}"))
+            .unwrap_err();
+        assert!(matches!(error, DatasetError::UnsupportedFilter { .. }));
+    }
+
+    #[test]
+    fn allows_different_stable_schemas_for_different_metrics() {
+        let dataset = SeriesDataset::from_reader(
+            "metric,job,instance,region\nrequests,api,a,\nrequests,api,b,\nlatency,,,us-east\nlatency,,,us-west\n"
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            dataset.schema().get_labels("requests").unwrap().labels,
+            vec!["instance", "job"]
+        );
+        assert_eq!(
+            dataset.schema().get_labels("latency").unwrap().labels,
+            vec!["region"]
+        );
+    }
+
+    #[test]
+    fn rejects_missing_and_extra_workload_metrics() {
+        let dataset =
+            SeriesDataset::from_reader("metric,job\nrequests,api\nother,worker\n".as_bytes())
+                .unwrap();
+        let requests = AQE {
+            requirements: requirements("requests", &["job"], ""),
+            query_strings: vec![],
+            query_frequency_hz: 1.0,
+            min_t_repeat_ms: 1,
+            t_repeat_gcd_ms: 1,
+        };
+
+        assert!(matches!(
+            dataset.profile_aqes(&[requests]),
+            Err(DatasetError::ExtraMetric(metric)) if metric == "other"
+        ));
+    }
+
+    #[test]
+    fn validates_existing_metric_hints_against_dataset_schema() {
+        let dataset =
+            SeriesDataset::from_reader("metric,job,instance\nrequests,api,a\n".as_bytes()).unwrap();
+        let matching = MetricDefinition {
+            metric: "requests".into(),
+            labels: vec!["instance".into(), "job".into()],
+        };
+        let mismatching = MetricDefinition {
+            metric: "requests".into(),
+            labels: vec!["job".into()],
+        };
+
+        assert!(dataset.validate_metric_hints(Some(&[matching])).is_ok());
+        assert!(matches!(
+            dataset.validate_metric_hints(Some(&[mismatching])),
+            Err(DatasetError::MetricHintMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_grouping_labels() {
+        let dataset = SeriesDataset::from_reader("metric,job\nrequests,api\n".as_bytes()).unwrap();
+
+        assert!(matches!(
+            dataset.profile(&requirements("requests", &["instance"], "")),
+            Err(DatasetError::MissingLabel { .. })
+        ));
+    }
+}

--- a/asap-planner-rs/src/optimizer/greedy.rs
+++ b/asap-planner-rs/src/optimizer/greedy.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+
 use tracing::debug;
 
 use super::atomic_costs::{resolve_atomic_costs, AtomicCostTable};
-use super::candidate_gen::enumerate_candidates;
+use super::candidate_gen::enumerate_candidates_with_label_group_count;
 use super::cost_model::{ingest_cost, query_cost, total_cost_rate, AtomicCosts, CostWeights};
+use super::dataset::ProfileKey;
 use super::solution::{AQEAssignment, OptimizerSolution, AQE};
 
 /// Greedily assign each AQE to its independently-cheapest candidate config.
@@ -25,11 +28,23 @@ pub fn greedy_assign(
     arrival_rate_hz: f64,
     atomic_cost_table: &AtomicCostTable,
     weights: &CostWeights,
+    label_group_counts: &HashMap<ProfileKey, u64>,
 ) -> OptimizerSolution {
     let mut solution = OptimizerSolution::empty();
 
     for aqe in aqes {
-        let candidates = enumerate_candidates(&aqe, scrape_interval_ms);
+        let profile_key = ProfileKey::from_requirements(&aqe.requirements);
+        let label_group_count = *label_group_counts.get(&profile_key).unwrap_or_else(|| {
+            panic!(
+                "missing dataset profile for metric '{}' and grouping labels {:?}",
+                aqe.requirements.metric, aqe.requirements.grouping_labels.labels
+            )
+        });
+        let candidates = enumerate_candidates_with_label_group_count(
+            &aqe,
+            scrape_interval_ms,
+            label_group_count,
+        );
 
         let (best, costs) = candidates
             .into_iter()
@@ -86,6 +101,8 @@ pub fn greedy_assign(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use asap_types::query_requirements::QueryRequirements;
     use promql_utilities::data_model::KeyByLabelNames;
@@ -121,6 +138,20 @@ mod tests {
             1.0,
             &AtomicCostTable::default(),
             &CostWeights::default(),
+            &HashMap::from([
+                (
+                    ProfileKey::from_requirements(
+                        &make_aqe(Statistic::Min, 300_000, 300_000, 1.0 / 60.0).requirements,
+                    ),
+                    1,
+                ),
+                (
+                    ProfileKey::from_requirements(
+                        &make_aqe(Statistic::Max, 300_000, 300_000, 1.0 / 60.0).requirements,
+                    ),
+                    1,
+                ),
+            ]),
         );
 
         let mut seen_ids: StdHashMap<u64, ()> = StdHashMap::new();
@@ -150,11 +181,12 @@ mod tests {
             t_repeat_gcd_ms: 60_000,
         };
         let solution = greedy_assign(
-            vec![aqe],
+            vec![aqe.clone()],
             60_000,
             1.0,
             &AtomicCostTable::default(),
             &CostWeights::default(),
+            &HashMap::from([(ProfileKey::from_requirements(&aqe.requirements), 1)]),
         );
         assert_eq!(solution.num_exact_fallback(), 1);
         assert!(solution.deployed_configs().is_empty());

--- a/asap-planner-rs/src/optimizer/mod.rs
+++ b/asap-planner-rs/src/optimizer/mod.rs
@@ -3,6 +3,7 @@ pub mod atomic_costs;
 pub mod candidate_gen;
 pub mod constants;
 pub mod cost_model;
+pub mod dataset;
 pub mod greedy;
 pub mod pipeline;
 pub mod sketch_properties;
@@ -13,8 +14,11 @@ pub use aqe_extractor::{extract_aqes, RQE};
 pub use atomic_costs::{
     load_atomic_cost_table, resolve_atomic_costs, AtomicCostEntry, AtomicCostTable,
 };
-pub use candidate_gen::{enumerate_candidates, CandidateConfig};
+pub use candidate_gen::{
+    enumerate_candidates, enumerate_candidates_with_label_group_count, CandidateConfig,
+};
 pub use cost_model::{ingest_cost, query_cost, total_cost_rate, AtomicCosts, CostWeights};
+pub use dataset::{DatasetError, ProfileKey, SeriesDataset};
 pub use greedy::greedy_assign;
 pub use pipeline::{run_all_exact_pipeline, run_greedy_pipeline};
 pub use sketch_properties::{sketch_properties, SketchProperties};

--- a/asap-planner-rs/src/optimizer/pipeline.rs
+++ b/asap-planner-rs/src/optimizer/pipeline.rs
@@ -7,6 +7,7 @@ use crate::config::input::ControllerConfig;
 use super::aqe_extractor::{extract_aqes, RQE};
 use super::atomic_costs::AtomicCostTable;
 use super::cost_model::CostWeights;
+use super::dataset::SeriesDataset;
 use super::greedy::greedy_assign;
 use super::solution::{OptimizerSolution, AQE};
 use super::translator::{translate, TranslationSummary};
@@ -24,6 +25,13 @@ fn run_pipeline(
     let aqes = extract_aqes(&rqes, schema, scrape_interval_ms);
     let solution = solve(aqes);
 
+    finish_pipeline(solution, solver_name)
+}
+
+fn finish_pipeline(
+    solution: OptimizerSolution,
+    solver_name: &str,
+) -> (StreamingConfig, InferenceConfig) {
     let summary = TranslationSummary::from_solution(&solution);
     tracing::info!(
         solver = solver_name,
@@ -66,25 +74,42 @@ pub fn run_all_exact_pipeline(
 /// No cross-AQE sharing — every deployed sketch serves exactly one AQE, even
 /// if two AQEs could share one. The Phase 3 MIP finds sharing opportunities.
 ///
-/// `arrival_rate_hz` is a placeholder arrival rate applied uniformly to every
-/// candidate's IngestCost; real per-config rates need Prometheus scrape-rate ×
-/// series-count data, which isn't wired up yet (see implementation plan TODOs).
+/// The dataset supplies each AQE's metric schema and label-group count before
+/// candidate selection. `arrival_rate_hz` remains a uniform placeholder until
+/// per-config scrape-rate data is available.
 pub fn run_greedy_pipeline(
     config: &ControllerConfig,
-    schema: &PromQLSchema,
+    dataset: &SeriesDataset,
     scrape_interval_ms: u64,
     arrival_rate_hz: f64,
     atomic_cost_table: &AtomicCostTable,
-) -> (StreamingConfig, InferenceConfig) {
-    run_pipeline(config, schema, scrape_interval_ms, "greedy", |aqes| {
-        greedy_assign(
-            aqes,
-            scrape_interval_ms,
-            arrival_rate_hz,
-            atomic_cost_table,
-            &CostWeights::default(),
-        )
-    })
+) -> Result<(StreamingConfig, InferenceConfig), super::dataset::DatasetError> {
+    dataset.validate_metric_hints(config.metrics.as_deref())?;
+    let schema = dataset.schema();
+    let rqes = config_to_rqes(config);
+    let aqes = extract_aqes(&rqes, &schema, scrape_interval_ms);
+    let label_group_counts = dataset.profile_aqes(&aqes)?;
+
+    for (key, count) in &label_group_counts {
+        tracing::info!(
+            metric = %key.metric,
+            spatial_filter = %key.spatial_filter_normalized,
+            grouping_labels = ?key.grouping_labels.labels,
+            label_group_count = *count,
+            "optimizer dataset profile"
+        );
+    }
+
+    let solution = greedy_assign(
+        aqes,
+        scrape_interval_ms,
+        arrival_rate_hz,
+        atomic_cost_table,
+        &CostWeights::default(),
+        &label_group_counts,
+    );
+
+    Ok(finish_pipeline(solution, "greedy"))
 }
 
 /// Convert a `ControllerConfig`'s query groups into a flat list of RQEs.
@@ -147,11 +172,23 @@ mod tests {
     #[test]
     fn greedy_pipeline_deploys_a_config_for_a_mergeable_aqe() {
         let config = make_config(&[("min_over_time(metric[5m])", 60_000)]);
-        let schema = PromQLSchema::new();
+        let dataset = SeriesDataset::from_reader("metric,job\nmetric,api\n".as_bytes()).unwrap();
         let (streaming, inference) =
-            run_greedy_pipeline(&config, &schema, 60_000, 1.0, &AtomicCostTable::default());
+            run_greedy_pipeline(&config, &dataset, 60_000, 1.0, &AtomicCostTable::default())
+                .unwrap();
         assert!(!streaming.get_all_aggregation_configs().is_empty());
         assert!(!inference.query_configs.is_empty());
+    }
+
+    #[test]
+    fn greedy_pipeline_fails_when_dataset_does_not_match_workload() {
+        let config = make_config(&[("min_over_time(metric[5m])", 60_000)]);
+        let dataset = SeriesDataset::from_reader("metric,job\nother,api\n".as_bytes()).unwrap();
+
+        assert!(matches!(
+            run_greedy_pipeline(&config, &dataset, 60_000, 1.0, &AtomicCostTable::default()),
+            Err(super::super::dataset::DatasetError::MissingMetric(metric)) if metric == "metric"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #693, the offline dataset-backed path for inferring label-group cardinality N_g.

- Adds a CSV series-inventory loader: one row per unique metric series, with a fixed metric column.
- Derives per-metric schemas and per-profile distinct grouping counts after exact label filters.
- Requires --dataset for the greedy optimizer CLI and fails loudly on missing metrics, labels, filters, empty matches, schema drift, duplicates, and unused columns.
- Threads integer counts into candidates and applies them only to non-subpopulation-aware ingest/query costs.
- Keeps dataset parsing separate from optimizer core so #525 can later supply an equivalent Prometheus-backed profile provider.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p asap_planner --all-targets -- -D warnings
- cargo test --workspace (all tests passed)

Sketch-bench PR 123 adds explicit, bounded timestamped external trace adapters and metadata. It is complementary infrastructure; this PR consumes a static series inventory for planner cardinality and does not couple the planner to those trace formats.

Part of #525.