### PR TITLE
test(query-engine): expand PromQL compliance coverage

### DIFF
--- a/.github/workflows/promql-differential.yml
+++ b/.github/workflows/promql-differential.yml
@@ -26,7 +26,7 @@ jobs:
   differential:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run live PromQL differential suite
         working-directory: promql-compliance/runner
-        run: make run
+        run: make run-all
 
       - name: Upload differential report and service logs
         if: always()
@@ -63,6 +63,6 @@ jobs:
         with:
           name: promql-differential-results
           path: |
-            promql-compliance/runner/differential-report.json
+            /tmp/asapquery-differential-reports/*.json
             /tmp/asapquery-differential-*
           if-no-files-found: warn

--- a/.github/workflows/promql-differential.yml
+++ b/.github/workflows/promql-differential.yml
@@ -1,17 +1,17 @@
 name: PromQL Differential Tests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
-    paths:
-      - 'promql-compliance/**'
-      - 'asap-query-engine/**'
-      - 'asap-planner-rs/**'
-      - 'asap-common/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/promql-differential.yml'
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review]
+  #   branches: [main]
+  #   paths:
+  #     - 'promql-compliance/**'
+  #     - 'asap-query-engine/**'
+  #     - 'asap-planner-rs/**'
+  #     - 'asap-common/**'
+  #     - 'Cargo.toml'
+  #     - 'Cargo.lock'
+  #     - '.github/workflows/promql-differential.yml'
   workflow_dispatch:
 
 concurrency:

--- a/promql-compliance/HOW_TO.md
+++ b/promql-compliance/HOW_TO.md
@@ -82,6 +82,28 @@ go run ./cmd/differential-runner \
   --compose-file ../docker-compose.yml
 ```
 
+The default `make run` target uses `single-rate.yaml` and `temporal.yaml`.
+To run another pair through the same target, pass the paths as Make variables:
+
+```bash
+make run \
+  DATASET=../datasets/aggregations.yaml \
+  SUITE=../suites/aggregations.yaml
+```
+
+The PromQL differential CI workflow runs the checked-in pairs listed in the
+runner Makefile's `CASES` variable. Adding a YAML file does not automatically
+add it to CI; add a case there when adding a new dataset/suite pair.
+
+To run all checked-in pairs locally and write one report per pair:
+
+```bash
+make run-all
+```
+
+Reports are written to `/tmp/asapquery-differential-reports` by default. Set
+`REPORT_DIR` to choose another output directory.
+
 ## Change query timing
 
 `range.step_seconds` controls the evaluation cadence of a range query. It is

--- a/promql-compliance/datasets/aggregations.yaml
+++ b/promql-compliance/datasets/aggregations.yaml
@@ -1,0 +1,136 @@
+name: aggregations
+series:
+  # The first series in each job is sampled every minute. The second series
+  # has a sparser cadence so count_over_time and topk have non-trivial output.
+  - metric: data
+    labels:
+      job: frontend
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 100}
+      - {offset_seconds: 60, value: 160}
+      - {offset_seconds: 120, value: 220}
+      - {offset_seconds: 180, value: 280}
+      - {offset_seconds: 240, value: 340}
+      - {offset_seconds: 300, value: 400}
+      - {offset_seconds: 360, value: 460}
+      - {offset_seconds: 420, value: 520}
+      - {offset_seconds: 480, value: 580}
+      - {offset_seconds: 540, value: 640}
+      - {offset_seconds: 600, value: 700}
+      - {offset_seconds: 660, value: 760}
+      - {offset_seconds: 720, value: 820}
+      - {offset_seconds: 780, value: 880}
+      - {offset_seconds: 840, value: 940}
+      - {offset_seconds: 900, value: 1000}
+      - {offset_seconds: 960, value: 1060}
+      - {offset_seconds: 1020, value: 1120}
+      - {offset_seconds: 1080, value: 1180}
+      - {offset_seconds: 1140, value: 1240}
+      - {offset_seconds: 1200, value: 1300}
+  - metric: data
+    labels:
+      job: frontend
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 200}
+      - {offset_seconds: 60, value: 320}
+      - {offset_seconds: 120, value: 440}
+      - {offset_seconds: 180, value: 560}
+      - {offset_seconds: 240, value: 680}
+      - {offset_seconds: 300, value: 800}
+      - {offset_seconds: 360, value: 920}
+      - {offset_seconds: 420, value: 1040}
+      - {offset_seconds: 480, value: 1160}
+      - {offset_seconds: 540, value: 1280}
+      - {offset_seconds: 600, value: 1400}
+      - {offset_seconds: 660, value: 1520}
+      - {offset_seconds: 720, value: 1640}
+      - {offset_seconds: 780, value: 1760}
+      - {offset_seconds: 840, value: 1880}
+      - {offset_seconds: 900, value: 2000}
+      - {offset_seconds: 960, value: 2120}
+      - {offset_seconds: 1020, value: 2240}
+      - {offset_seconds: 1080, value: 2360}
+      - {offset_seconds: 1140, value: 2480}
+      - {offset_seconds: 1200, value: 2600}
+  - metric: data
+    labels:
+      job: backend
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 300}
+      - {offset_seconds: 60, value: 480}
+      - {offset_seconds: 120, value: 660}
+      - {offset_seconds: 180, value: 840}
+      - {offset_seconds: 240, value: 1020}
+      - {offset_seconds: 300, value: 1200}
+      - {offset_seconds: 360, value: 1380}
+      - {offset_seconds: 420, value: 1560}
+      - {offset_seconds: 480, value: 1740}
+      - {offset_seconds: 540, value: 1920}
+      - {offset_seconds: 600, value: 2100}
+      - {offset_seconds: 660, value: 2280}
+      - {offset_seconds: 720, value: 2460}
+      - {offset_seconds: 780, value: 2640}
+      - {offset_seconds: 840, value: 2820}
+      - {offset_seconds: 900, value: 3000}
+      - {offset_seconds: 960, value: 3180}
+      - {offset_seconds: 1020, value: 3360}
+      - {offset_seconds: 1080, value: 3540}
+      - {offset_seconds: 1140, value: 3720}
+      - {offset_seconds: 1200, value: 3900}
+  - metric: data
+    labels:
+      job: backend
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 400}
+      - {offset_seconds: 120, value: 880}
+      - {offset_seconds: 240, value: 1360}
+      - {offset_seconds: 360, value: 1840}
+      - {offset_seconds: 480, value: 2320}
+      - {offset_seconds: 600, value: 2800}
+      - {offset_seconds: 720, value: 3280}
+      - {offset_seconds: 840, value: 3760}
+      - {offset_seconds: 960, value: 4240}
+      - {offset_seconds: 1080, value: 4720}
+      - {offset_seconds: 1200, value: 5200}
+  - metric: data
+    labels:
+      job: worker
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 500}
+      - {offset_seconds: 60, value: 800}
+      - {offset_seconds: 120, value: 1100}
+      - {offset_seconds: 180, value: 1400}
+      - {offset_seconds: 240, value: 1700}
+      - {offset_seconds: 300, value: 2000}
+      - {offset_seconds: 360, value: 2300}
+      - {offset_seconds: 420, value: 2600}
+      - {offset_seconds: 480, value: 2900}
+      - {offset_seconds: 540, value: 3200}
+      - {offset_seconds: 600, value: 3500}
+      - {offset_seconds: 660, value: 3800}
+      - {offset_seconds: 720, value: 4100}
+      - {offset_seconds: 780, value: 4400}
+      - {offset_seconds: 840, value: 4700}
+      - {offset_seconds: 900, value: 5000}
+      - {offset_seconds: 960, value: 5300}
+      - {offset_seconds: 1020, value: 5600}
+      - {offset_seconds: 1080, value: 5900}
+      - {offset_seconds: 1140, value: 6200}
+      - {offset_seconds: 1200, value: 6500}
+  - metric: data
+    labels:
+      job: worker
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 600}
+      - {offset_seconds: 180, value: 1680}
+      - {offset_seconds: 360, value: 2760}
+      - {offset_seconds: 540, value: 3840}
+      - {offset_seconds: 720, value: 4920}
+      - {offset_seconds: 900, value: 6000}
+      - {offset_seconds: 1080, value: 7080}

--- a/promql-compliance/runner/Makefile
+++ b/promql-compliance/runner/Makefile
@@ -1,10 +1,40 @@
-.PHONY: test run
+.PHONY: test run run-all
+
+DATASET ?= ../datasets/single-rate.yaml
+SUITE ?= ../suites/temporal.yaml
+REPORT_DIR ?= /tmp/asapquery-differential-reports
+
+CASES := \
+	single-rate-temporal:../datasets/single-rate.yaml:../suites/temporal.yaml \
+	sparse-checkout-temporal:../datasets/sparse-checkout.yaml:../suites/temporal.yaml \
+	aggregations:../datasets/aggregations.yaml:../suites/aggregations.yaml
 
 test:
 	go test ./...
 
 run:
 	go run ./cmd/differential-runner \
-		--dataset ../datasets/single-rate.yaml \
-		--suite ../suites/temporal.yaml \
+		--dataset $(DATASET) \
+		--suite $(SUITE) \
 		--compose-file ../docker-compose.yml
+
+run-all:
+	@set -eu; \
+	mkdir -p "$(REPORT_DIR)"; \
+	result=0; \
+	for test_case in $(CASES); do \
+		name="$${test_case%%:*}"; \
+		rest="$${test_case#*:}"; \
+		dataset="$${rest%%:*}"; \
+		suite="$${rest#*:}"; \
+		echo "Running $$name ($$dataset, $$suite)"; \
+		if ! go run ./cmd/differential-runner \
+			--dataset "$$dataset" \
+			--suite "$$suite" \
+			--compose-file ../docker-compose.yml \
+			--output "$(REPORT_DIR)/$$name.json"; then \
+			echo "FAILED: $$name" >&2; \
+			result=1; \
+		fi; \
+	done; \
+	exit $$result

--- a/promql-compliance/runner/checked_in_fixture_validation_test.go
+++ b/promql-compliance/runner/checked_in_fixture_validation_test.go
@@ -1,0 +1,24 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/ProjectASAP/ASAPQuery/promql-compliance/seeder"
+	promqlparser "github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestCheckedInAggregationFixtureAndSuite(t *testing.T) {
+	if _, err := seeder.LoadFixture("../datasets/aggregations.yaml"); err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	suite, err := LoadSuiteFile("../suites/aggregations.yaml")
+	if err != nil {
+		t.Fatalf("LoadSuiteFile: %v", err)
+	}
+	parser := promqlparser.NewParser(promqlparser.Options{})
+	for _, query := range suite.Queries {
+		if _, err := parser.ParseExpr(query.Expr); err != nil {
+			t.Fatalf("parse %q: %v", query.Expr, err)
+		}
+	}
+}

--- a/promql-compliance/suites/aggregations.yaml
+++ b/promql-compliance/suites/aggregations.yaml
@@ -1,0 +1,269 @@
+name: aggregations
+comparison_defaults:
+  value_tolerance:
+    relative: 0.01
+    absolute: 0.000001
+
+queries:
+  # Every query is exercised as both instant and range. Keep the evaluation
+  # grid shared so the runner's range/instant parity check applies uniformly.
+  - name: increase
+    expr: "increase(data[5m])"
+    instant_offsets_seconds: &evaluation_offsets [300, 600, 900, 1200]
+    range: &evaluation_range
+      start_offset_seconds: 300
+      end_offset_seconds: 1200
+      step_seconds: 60
+
+  - name: rate
+    expr: "rate(data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  - name: quantile-over-time-0.1
+    expr: "quantile_over_time(0.1, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.2
+    expr: "quantile_over_time(0.2, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.3
+    expr: "quantile_over_time(0.3, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.4
+    expr: "quantile_over_time(0.4, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.5
+    expr: "quantile_over_time(0.5, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.6
+    expr: "quantile_over_time(0.6, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.7
+    expr: "quantile_over_time(0.7, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.8
+    expr: "quantile_over_time(0.8, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.9
+    expr: "quantile_over_time(0.9, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.95
+    expr: "quantile_over_time(0.95, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-over-time-0.99
+    expr: "quantile_over_time(0.99, data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  - name: sum-over-time
+    expr: "sum_over_time(data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: count-over-time
+    expr: "count_over_time(data[5m])"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  # Zero-label grouping is the ordinary aggregate form. One- and two-label
+  # forms retain job, then job+instance, respectively.
+  - name: topk-1-sum-over-time
+    expr: "topk(1, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-sum-over-time
+    expr: "topk(3, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-sum-over-time
+    expr: "topk(5, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-sum-over-time
+    expr: "topk(10, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-1-sum-over-time-by-job
+    expr: "topk by (job) (1, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-sum-over-time-by-job
+    expr: "topk by (job) (3, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-sum-over-time-by-job
+    expr: "topk by (job) (5, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-sum-over-time-by-job
+    expr: "topk by (job) (10, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-1-sum-over-time-by-job-instance
+    expr: "topk by (job, instance) (1, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-sum-over-time-by-job-instance
+    expr: "topk by (job, instance) (3, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-sum-over-time-by-job-instance
+    expr: "topk by (job, instance) (5, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-sum-over-time-by-job-instance
+    expr: "topk by (job, instance) (10, sum_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  - name: topk-1-count-over-time
+    expr: "topk(1, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-count-over-time
+    expr: "topk(3, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-count-over-time
+    expr: "topk(5, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-count-over-time
+    expr: "topk(10, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-1-count-over-time-by-job
+    expr: "topk by (job) (1, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-count-over-time-by-job
+    expr: "topk by (job) (3, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-count-over-time-by-job
+    expr: "topk by (job) (5, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-count-over-time-by-job
+    expr: "topk by (job) (10, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-1-count-over-time-by-job-instance
+    expr: "topk by (job, instance) (1, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-count-over-time-by-job-instance
+    expr: "topk by (job, instance) (3, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-count-over-time-by-job-instance
+    expr: "topk by (job, instance) (5, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-count-over-time-by-job-instance
+    expr: "topk by (job, instance) (10, count_over_time(data[5m]))"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  - name: quantile-0.1
+    expr: "quantile(0.1, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.2
+    expr: "quantile(0.2, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.3
+    expr: "quantile(0.3, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.4
+    expr: "quantile(0.4, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.5
+    expr: "quantile(0.5, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.6
+    expr: "quantile(0.6, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.7
+    expr: "quantile(0.7, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.8
+    expr: "quantile(0.8, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.9
+    expr: "quantile(0.9, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.95
+    expr: "quantile(0.95, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.99
+    expr: "quantile(0.99, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.5-by-job
+    expr: "quantile by (job) (0.5, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.95-by-job
+    expr: "quantile by (job) (0.95, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.99-by-job
+    expr: "quantile by (job) (0.99, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.5-by-job-instance
+    expr: "quantile by (job, instance) (0.5, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.95-by-job-instance
+    expr: "quantile by (job, instance) (0.95, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: quantile-0.99-by-job-instance
+    expr: "quantile by (job, instance) (0.99, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
+  - name: sum
+    expr: "sum(data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: sum-by-job
+    expr: "sum by (job) (data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: sum-by-job-instance
+    expr: "sum by (job, instance) (data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: count
+    expr: "count(data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: count-by-job
+    expr: "count by (job) (data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: count-by-job-instance
+    expr: "count by (job, instance) (data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range


### PR DESCRIPTION
FYI @zzylol

## Summary
- Add a six-series, two-label aggregation fixture with sparse samples for count/topk coverage.
- Add 62 PromQL compliance cases covering increase, rate, quantile_over_time, sum/count_over_time, grouped quantile/sum/count, and topk with k values 1, 3, 5, and 10.
- Exercise every case through both instant and range queries with 1% relative tolerance.
- Run all checked-in dataset/suite pairs sequentially in one CI job and preserve one report per pair.
- Add fixture and PromQL parser validation.

## Validation
- go test ./... in promql-compliance/runner
- go test ./... in promql-compliance/seeder
- pre-commit checks passed
- Makefile run-all shell syntax checked

The Docker-backed differential run was not available in the local environment; CI will execute it.