### PR TITLE
fix(asap-tools): install experiment test requirements

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install Jinja2==3.1.2 PyYAML==6.0.2 omegaconf==2.3.0
+        pip install -r asap-tools/experiments/requirements.txt
     - name: Run experiment tests
       working-directory: asap-tools/experiments
       run: python -m unittest discover -s tests -p 'test_*.py' -v


### PR DESCRIPTION
## Summary
- install the experiment test suite from its declared requirements file
- include hydra-core required by the ClickHouse controller regression test

## Testing
- python -m unittest discover -s tests -p 'test_*.py' -v (from asap-tools/experiments)