### PR TITLE
fix(precompute): use open-closed evaluation windows

### DIFF
--- a/asap-query-engine/src/precompute_engine/precompute_engine_design_doc.md
+++ b/asap-query-engine/src/precompute_engine/precompute_engine_design_doc.md
@@ -75,19 +75,19 @@ Watermark (max_ts - allowed_lateness, where lateness=2):
 Window Lifecycle (window_size=5, slide=5):
                                                         │
   ┌─────────────────────┐                               │
-  │  Window [0, 5)      │                               │
-  │  collects: t=3,1,2,4│                               │
+  │  Window (0, 5]      │                               │
+  │ collects: t=3,1,5,2,4                               │
   │                     │── W=5 crosses end ──► EMIT    │
   └─────────────────────┘                               │
                                                         │
         ┌─────────────────────┐                         │
-        │  Window [5, 10)     │                         │
-        │  collects: t=5,7,9,6│                         │
+        │  Window (5, 10]     │                         │
+        │  collects: t=7,9,6,8│                         │
         │                     │── W=11 crosses end      │
         └─────────────────────┘           ──► EMIT      │
                                                         │
               ┌─────────────────────┐                   │
-              │  Window [10, 15)    │                    │
+              │  Window (10, 15]    │                    │
               │  collects: t=11,13  │  (still open,     │
               │  ...waiting...      │   W=11 < 15)      │
               └─────────────────────┘                   │
@@ -144,7 +144,7 @@ watermarks across all workers.
               global_wm = min(100s, 80s, 90s) = 80s
 
               On flush, each group's effective watermark becomes:
-                max(group_wm, global_wm) + 1ms
+                max(group_wm, global_wm)
 
               Worker 0: Group B (50s) → advanced to 80s → closes [50s, 80s] windows
               Worker 2: Group F (30s) → advanced to 80s → closes [30s, 80s] windows
@@ -316,7 +316,11 @@ for (id, rx) in receivers {
 
 ```rust
 let aggregations = matching_agg_configs(series_key).map(|(_, config)| AggregationState {
-    window_manager: WindowManager::new(config.window_size, config.slide_interval),
+    window_manager: WindowManager::new(
+        config.window_size,
+        config.slide_interval,
+        WindowBoundary::OpenClosed,
+    )?,
     config: config.clone(),
     active_panes: BTreeMap::new(),   // ← empty; no memory allocated for sketches yet
 }).collect();
@@ -350,10 +354,10 @@ of size `slide_interval`. Each window is composed of `W = window_size /
 slide_interval` consecutive panes. Consecutive windows share W-1 panes.
 
 ```
-Panes:     [0,10)  [10,20)  [20,30)  [30,40)  [40,50)
-Window A:  [───────── 0,30 ─────────)
-Window B:          [───────── 10,40 ─────────)
-Window C:                  [───────── 20,50 ─────────)
+Panes:     (0,10]  (10,20]  (20,30]  (30,40]  (40,50]
+Window A:  (───────── 0,30 ─────────]
+Window B:          (───────── 10,40 ─────────]
+Window C:                  (───────── 20,50 ─────────]
 ```
 
 **Why panes instead of subtraction?** Only Sum is invertible. MinMax, Increase,
@@ -376,11 +380,11 @@ zero merges — identical behavior to the non-pane approach.
 
 | Method | Description |
 |--------|-------------|
-| `pane_start_for(ts)` | Align timestamp to slide grid (same as `window_start_for`) |
-| `panes_for_window(ws)` | All pane starts composing window `[ws, ws+size)` |
+| `pane_start_for(ts)` | Assign to the pane ending at an exact grid boundary; otherwise align down |
+| `panes_for_window(ws)` | All pane starts composing window `(ws, ws+size]` |
 | `snapshot_accumulator()` | Non-destructive read of a pane's accumulator (for shared panes) |
 
-**Pane eviction:** When window `[S, S+W)` closes, pane `[S, S+slide)` is the
+**Pane eviction:** When window `(S, S+W]` closes, pane `(S, S+slide]` is the
 oldest pane and is not needed by any later window (next window starts at
 `S+slide`). It is destructively consumed via `take_accumulator()` and removed
 from `active_panes`. Remaining panes are read non-destructively via
@@ -439,6 +443,7 @@ Handles both tumbling and sliding window semantics.
 struct WindowManager {
     window_size_ms: i64,       // e.g. 60_000
     slide_interval_ms: i64,    // == window_size for tumbling; < window_size for sliding
+    boundary: WindowBoundary,  // currently only OpenClosed is supported
 }
 ```
 
@@ -447,15 +452,21 @@ struct WindowManager {
 | Method | Description |
 |--------|-------------|
 | `window_start_for(ts)` | Align timestamp down to nearest slide boundary |
-| `window_starts_containing(ts)` | All windows whose `[start, start+size)` includes `ts`. Tumbling → 1 window; sliding → `ceil(size/slide)` windows |
+| `window_starts_containing(ts)` | All windows whose `(start, start+size]` includes `ts`. Tumbling → 1 window; sliding → `ceil(size/slide)` windows |
 | `closed_windows(prev_wm, curr_wm)` | Windows that transitioned open→closed as the watermark advanced |
-| `window_bounds(start)` | Returns `(start, start + window_size_ms)` |
-| `pane_start_for(ts)` | Pane start for a timestamp (same slide-aligned grid as `window_start_for`) |
-| `panes_for_window(ws)` | All pane starts composing window `[ws, ws+size)`, in ascending order |
+| `window_bounds(start)` | Returns the numeric `(start, start + window_size_ms]` endpoints |
+| `pane_start_for(ts)` | Owning pane start under the configured endpoint semantics |
+| `panes_for_window(ws)` | All pane starts composing window `(ws, ws+size]`, in ascending order |
 | `slide_interval_ms()` | Slide interval accessor |
 
-**Window closure rule:** a window `[S, S + size)` closes when `watermark >= S + size`.
+**Window closure rule:** a window `(S, S + size]` closes when observed event time is
+strictly greater than `S + size`. This lets separately delivered samples exactly at
+the right endpoint join the same pane before it is evicted.
 Once closed, a window never reopens.
+
+`WindowBoundary` represents all four endpoint combinations (`OpenOpen`,
+`OpenClosed`, `ClosedOpen`, and `ClosedClosed`). The precompute engine currently
+accepts only `OpenClosed`; constructing a manager with another variant fails.
 
 #### Sliding window mechanics
 
@@ -468,11 +479,13 @@ let n = timestamp_ms.div_euclid(slide_interval_ms);
 n * slide_interval_ms
 ```
 
-**`window_starts_containing(ts)`** returns all windows whose `[start, start+size)`
-contains the timestamp, by walking backwards from the aligned start:
+**`window_starts_containing(ts)`** returns all windows whose `(start, start+size]`
+contains the timestamp. `pane_start_for` first subtracts one millisecond before
+alignment so an exact boundary belongs to the pane ending there (timestamp zero
+is the nonnegative-origin exception), then walks backwards:
 ```rust
-let mut start = window_start_for(timestamp_ms);
-while start + window_size_ms > timestamp_ms {
+let mut start = pane_start_for(timestamp_ms);
+while start + window_size_ms >= timestamp_ms {
     starts.push(start);
     start -= slide_interval_ms;
 }
@@ -483,8 +496,8 @@ each sample belongs to `ceil(window_size / slide_interval)` overlapping windows.
 
 **Example** (30s window, 10s slide):
 ```
-t=15s → belongs to windows [0, 30s), [10s, 40s), [-10s, 20s)   (3 windows)
-t=35s → belongs to windows [30s, 60s), [20s, 50s), [10s, 40s)  (3 windows)
+t=15s → belongs to windows (0, 30s], (10s, 40s], (-10s, 20s]   (3 windows)
+t=30s → belongs to windows (0, 30s], (10s, 40s], (20s, 50s]    (3 windows)
 ```
 
 **`closed_windows(prev_wm, curr_wm)`** finds windows that transitioned open→closed
@@ -571,10 +584,10 @@ metric{job=j1, instance=h1} → Worker 0 → pane accumulator with key (job=j1)
 metric{job=j1, instance=h2} → Worker 3 → pane accumulator with key (job=j1)
 ```
 
-Each worker independently closes its window and emits a separate `PrecomputedOutput` with key `(job=j1)` for the same window `[0, 60s)`. The store **appends** rather than overwrites on the same `(aggregation_id, key, window)` tuple:
+Each worker independently closes its window and emits a separate `PrecomputedOutput` with key `(job=j1)` for the same window `(0, 60s]`. The store **appends** rather than overwrites on the same `(aggregation_id, key, window)` tuple:
 
 ```
-store[(agg_id, key=(j1), [0,60s))] → [acc_worker0, acc_worker3]
+store[(agg_id, key=(j1), (0,60s])] → [acc_worker0, acc_worker3]
 ```
 
 Query-time `SummaryMergeMultipleExec` merges all entries for the same key and window via `AggregateCore::merge_with()`. No ingest-time cross-worker coordination is needed.
@@ -594,17 +607,17 @@ The pane-sharing optimization is an **intra-worker** implementation detail. From
 **Within a single worker** (e.g. Worker 0, series `{job=j1, instance=h1}`, 30s/10s sliding):
 
 ```
-Window [0, 30s)  — panes [0, 10s, 20s]
+Window (0, 30s]  — panes [0, 10s, 20s]
   pane 0:   take (evict — no future window needs it)
-  pane 10s: snapshot (shared with [10s, 40s))
-  pane 20s: snapshot (shared with [10s, 40s) and [20s, 50s))
-  → emit: acc_w0, key=(j1), window=[0,30s), sum = v_0 + v_10 + v_20
+  pane 10s: snapshot (shared with (10s, 40s])
+  pane 20s: snapshot (shared with (10s, 40s] and (20s, 50s])
+  → emit: acc_w0, key=(j1), window=(0,30s], sum = v_0 + v_10 + v_20
 
-Window [10s, 40s)  — panes [10s, 20s, 30s]
-  pane 10s: take (evict — snapshot for [0,30s) already completed)
+Window (10s, 40s]  — panes [10s, 20s, 30s]
+  pane 10s: take (evict — snapshot for (0,30s] already completed)
   pane 20s: snapshot
   pane 30s: snapshot (or take, depending on future windows)
-  → emit: acc_w0, key=(j1), window=[10s,40s), sum = v_10 + v_20 + v_30
+  → emit: acc_w0, key=(j1), window=(10s,40s], sum = v_10 + v_20 + v_30
 ```
 
 Worker 3 (series `{job=j1, instance=h2}`) performs the same steps independently — its own pane `BTreeMap`, its own snapshots, its own emits.
@@ -612,14 +625,14 @@ Worker 3 (series `{job=j1, instance=h2}`) performs the same steps independently 
 **What the store sees:**
 
 ```
-store[(agg_id, key=(j1), [0,  30s))] → [acc_w0, acc_w3]
-store[(agg_id, key=(j1), [10s,40s))] → [acc_w0, acc_w3]
-store[(agg_id, key=(j1), [20s,50s))] → [acc_w0, acc_w3]
+store[(agg_id, key=(j1), (0,  30s])] → [acc_w0, acc_w3]
+store[(agg_id, key=(j1), (10s,40s])] → [acc_w0, acc_w3]
+store[(agg_id, key=(j1), (20s,50s])] → [acc_w0, acc_w3]
 ```
 
 Each entry is a complete accumulator from one worker for one window. Query-time merge combines them identically to the tumbling case.
 
-The pane snapshot/take logic reduces memory and CPU inside each worker (avoiding re-accumulation of shared panes), but what exits the worker is always one standalone `Box<dyn AggregateCore>` per window. Consecutive sliding windows `[0,30s)` and `[10s,40s)` share panes *inside* the worker but have independent store entries — their cross-worker merges at query time are completely unrelated.
+The pane snapshot/take logic reduces memory and CPU inside each worker (avoiding re-accumulation of shared panes), but what exits the worker is always one standalone `Box<dyn AggregateCore>` per window. Consecutive sliding windows `(0,30s]` and `(10s,40s]` share panes *inside* the worker but have independent store entries — their cross-worker merges at query time are completely unrelated.
 
 ### Optional second-tier merge workers for cross-worker accumulator reduction
 
@@ -902,14 +915,14 @@ When a window is complete, the merge worker:
 This produces the canonical shape expected by merge-tier-enabled reads:
 
 ```
-store[(agg_id, key=(j1), [0,30s))]  -> [merged_acc]
-store[(agg_id, key=(j1), [10s,40s))] -> [merged_acc]
+store[(agg_id, key=(j1), (0,30s])]  -> [merged_acc]
+store[(agg_id, key=(j1), (10s,40s])] -> [merged_acc]
 ```
 
 and for tumbling windows:
 
 ```
-store[(agg_id, key=(j1), [0,60s))] -> [merged_acc]
+store[(agg_id, key=(j1), (0,60s]] -> [merged_acc]
 ```
 
 #### Query-path simplification
@@ -1092,7 +1105,7 @@ Two checks determine whether a sample is "late":
 
 2. **Window closure check** (window-level): the sample passes the watermark check
    but targets a window that is already closed
-   (`window not in active_windows && watermark >= window_end`).
+   (`window not in active_windows && watermark > window_end`).
 
 For case 2, the `LateDataPolicy` controls behavior:
 
@@ -1181,8 +1194,8 @@ store with the Kafka consumer path.
   | Test | What it verifies |
   |---|---|
   | `test_raw_mode_forwarding` | 3 samples -> 3 emits; `start == end == ts`, `SumAccumulator.sum == value` |
-  | `test_tumbling_window_correctness` | Samples at t=1s/5s/9s; window [0,10s) closes on t=10s; `sum=6` |
-  | `test_sliding_window_pane_sharing` | Sample at t=15s in 30s/10s window -> 2 emits for [0,30s) and [10s,40s), both `sum=42` via shared pane snapshot/take |
+| `test_tumbling_window_correctness` | Samples at t=1s/5s/9s/10s; window (0,10s] is emitted after time advances past 10s; `sum=106` |
+  | `test_sliding_window_pane_sharing` | Sample at t=15s in 30s/10s window -> 2 emits for (0,30s] and (10s,40s], both `sum=42` via shared pane snapshot/take |
   | `test_groupby_separate_emits_per_series` | Two series (`host=A`, `host=B`) on same worker -> 2 independent `MultipleSumAccumulator` emits (no ingest-time cross-series merge) |
   | `test_late_data_drop` | Sample behind `watermark - allowed_lateness_ms` with `Drop` policy -> 0 emits |
   | `test_late_data_forward_to_store` | Late sample for evicted pane with `ForwardToStore` -> 1 emit as mini-accumulator with correct window bounds and sum |

--- a/asap-query-engine/src/precompute_engine/window_manager.rs
+++ b/asap-query-engine/src/precompute_engine/window_manager.rs
@@ -1,13 +1,34 @@
+/// Inclusion semantics for the two endpoints of a precomputed time window.
+///
+/// Only [`WindowBoundary::OpenClosed`] is supported today. The complete enum
+/// makes the stored-window contract explicit without silently assigning
+/// semantics to configurations the precompute engine cannot yet honor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindowBoundary {
+    OpenOpen,
+    OpenClosed,
+    ClosedOpen,
+    ClosedClosed,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WindowManagerError {
+    #[error("unsupported precompute window boundary: {0:?}")]
+    UnsupportedWindowBoundary(WindowBoundary),
+}
+
 /// Manages tumbling and sliding window boundaries and detects which windows
 /// have closed based on watermark advancement.
 ///
 /// Tumbling windows are a special case where `slide_interval == window_size`.
 /// The same logic handles both — no separate code paths.
+#[derive(Debug)]
 pub struct WindowManager {
     /// Window size in milliseconds.
     window_size_ms: i64,
     /// Slide interval in milliseconds (== window_size_ms for tumbling windows).
     slide_interval_ms: i64,
+    boundary: WindowBoundary,
 }
 
 impl WindowManager {
@@ -15,16 +36,25 @@ impl WindowManager {
     ///
     /// `window_size_ms` and `slide_interval_ms` come straight from `AggregationConfig`,
     /// which is ms-typed already — no conversion needed here.
-    pub fn new(window_size_ms: u64, slide_interval_ms: u64) -> Self {
+    pub fn new(
+        window_size_ms: u64,
+        slide_interval_ms: u64,
+        boundary: WindowBoundary,
+    ) -> Result<Self, WindowManagerError> {
+        if boundary != WindowBoundary::OpenClosed {
+            return Err(WindowManagerError::UnsupportedWindowBoundary(boundary));
+        }
+
         let window_size_ms = window_size_ms as i64;
         let slide_interval_ms = match slide_interval_ms {
             0 => window_size_ms, // tumbling window
             ms => ms as i64,
         };
-        Self {
+        Ok(Self {
             window_size_ms,
             slide_interval_ms,
-        }
+            boundary,
+        })
     }
 
     pub fn window_size_ms(&self) -> i64 {
@@ -42,8 +72,10 @@ impl WindowManager {
     /// Return window starts whose windows are now closed, given that the
     /// watermark advanced from `previous_wm` to `current_wm`.
     ///
-    /// A window `[start, start + window_size_ms)` is closed when
-    /// `current_wm >= start + window_size_ms`.
+    /// A window `(start, start + window_size_ms]` is closed once the observed
+    /// watermark advances *past* its right endpoint. Waiting for `>` rather
+    /// than `>=` lets separately delivered samples with that same endpoint
+    /// timestamp join the window before its pane is evicted.
     ///
     /// Returns window starts in ascending order.
     pub fn closed_windows(&self, previous_wm: i64, current_wm: i64) -> Vec<i64> {
@@ -56,16 +88,15 @@ impl WindowManager {
         let mut closed = Vec::new();
 
         // The earliest window start that *could* have been open at previous_wm.
-        // A window is open if its end (start + window_size_ms) > previous_wm.
-        // So the oldest open window start was: previous_wm - window_size_ms + 1,
+        // A window is open if its end (start + window_size_ms) >= previous_wm.
+        // So the oldest open window start was: previous_wm - window_size_ms,
         // aligned down to slide_interval.
-        let earliest_open_start =
-            self.window_start_for((previous_wm - self.window_size_ms + 1).max(0));
+        let earliest_open_start = self.window_start_for((previous_wm - self.window_size_ms).max(0));
 
         let mut start = earliest_open_start;
-        while start + self.window_size_ms <= current_wm {
+        while start + self.window_size_ms < current_wm {
             // This window was NOT closed at previous_wm but IS closed at current_wm
-            if start + self.window_size_ms > previous_wm {
+            if start + self.window_size_ms >= previous_wm {
                 closed.push(start);
             }
             start += self.slide_interval_ms;
@@ -74,21 +105,21 @@ impl WindowManager {
         closed
     }
 
-    /// Return all window starts whose window `[start, start + window_size_ms)`
+    /// Return all window starts whose window `(start, start + window_size_ms]`
     /// contains the given timestamp. For tumbling windows this returns exactly
     /// one start; for sliding windows it returns `ceil(window_size / slide)`
     /// starts.
     pub fn window_starts_containing(&self, timestamp_ms: i64) -> Vec<i64> {
         let mut starts = Vec::new();
-        let mut start = self.window_start_for(timestamp_ms);
-        while start + self.window_size_ms > timestamp_ms {
+        let mut start = self.pane_start_for(timestamp_ms);
+        while start + self.window_size_ms >= timestamp_ms {
             starts.push(start);
             start -= self.slide_interval_ms;
         }
         starts
     }
 
-    /// Return the window `[start, end)` boundaries for a given window start.
+    /// Return the numeric `(start, end]` boundaries for a given window start.
     pub fn window_bounds(&self, window_start: i64) -> (i64, i64) {
         (window_start, window_start + self.window_size_ms)
     }
@@ -98,14 +129,27 @@ impl WindowManager {
         self.slide_interval_ms
     }
 
-    /// Pane start for a timestamp. Panes are aligned to the slide_interval grid,
-    /// which is the same grid as `window_start_for`.
+    /// Pane start owning a timestamp under this manager's endpoint semantics.
+    ///
+    /// For `(start, end]`, subtracting one millisecond before aligning moves an
+    /// exact grid-boundary sample into the pane ending at that boundary while
+    /// leaving every non-boundary sample in its existing pane. Timestamp zero
+    /// is the sole origin exception because stored timestamps are unsigned.
     pub fn pane_start_for(&self, timestamp_ms: i64) -> i64 {
-        self.window_start_for(timestamp_ms)
+        match self.boundary {
+            WindowBoundary::OpenClosed => {
+                if timestamp_ms == 0 {
+                    0
+                } else {
+                    self.window_start_for(timestamp_ms.saturating_sub(1))
+                }
+            }
+            _ => unreachable!("unsupported boundaries are rejected during construction"),
+        }
     }
 
     /// All pane starts composing a window, in ascending order.
-    /// A window `[ws, ws + window_size)` is composed of
+    /// A window `(ws, ws + window_size]` is composed of
     /// `window_size / slide_interval` consecutive panes.
     pub fn panes_for_window(&self, window_start: i64) -> Vec<i64> {
         let num_panes = self.window_size_ms / self.slide_interval_ms;
@@ -119,10 +163,33 @@ impl WindowManager {
 mod tests {
     use super::*;
 
+    fn open_closed_manager(window_size_ms: u64, slide_interval_ms: u64) -> WindowManager {
+        WindowManager::new(
+            window_size_ms,
+            slide_interval_ms,
+            WindowBoundary::OpenClosed,
+        )
+        .expect("OpenClosed is the supported precompute window boundary")
+    }
+
+    #[test]
+    fn unsupported_window_boundaries_fail_during_construction() {
+        for boundary in [
+            WindowBoundary::OpenOpen,
+            WindowBoundary::ClosedOpen,
+            WindowBoundary::ClosedClosed,
+        ] {
+            assert_eq!(
+                WindowManager::new(60_000, 0, boundary).unwrap_err(),
+                WindowManagerError::UnsupportedWindowBoundary(boundary)
+            );
+        }
+    }
+
     #[test]
     fn test_tumbling_window_start() {
         // 60-second (60000ms) tumbling windows
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
 
         assert_eq!(wm.window_start_for(0), 0);
         assert_eq!(wm.window_start_for(59_999), 0);
@@ -133,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_no_closed_windows_on_first_sample() {
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
         let closed = wm.closed_windows(i64::MIN, 30_000);
         assert!(closed.is_empty());
     }
@@ -141,10 +208,10 @@ mod tests {
     #[test]
     fn test_tumbling_window_close() {
         // 60s tumbling windows
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
 
         // Watermark advances from 30_000 to 70_000
-        // Window [0, 60_000) closes when wm >= 60_000
+        // Window (0, 60_000] closes when wm advances past 60_000.
         let closed = wm.closed_windows(30_000, 70_000);
         assert_eq!(closed, vec![0]);
     }
@@ -152,7 +219,7 @@ mod tests {
     #[test]
     fn test_multiple_window_closes() {
         // 10s (10000ms) tumbling windows
-        let wm = WindowManager::new(10_000, 0);
+        let wm = open_closed_manager(10_000, 0);
 
         // Watermark jumps from 5_000 to 35_000 — closes windows 0, 10_000, 20_000
         let closed = wm.closed_windows(5_000, 35_000);
@@ -161,14 +228,14 @@ mod tests {
 
     #[test]
     fn test_no_close_when_watermark_stagnant() {
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
         let closed = wm.closed_windows(30_000, 30_000);
         assert!(closed.is_empty());
     }
 
     #[test]
     fn test_window_bounds() {
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
         assert_eq!(wm.window_bounds(0), (0, 60_000));
         assert_eq!(wm.window_bounds(60_000), (60_000, 120_000));
     }
@@ -176,14 +243,14 @@ mod tests {
     #[test]
     fn test_sliding_window() {
         // 30s window, 10s slide
-        let wm = WindowManager::new(30_000, 10_000);
+        let wm = open_closed_manager(30_000, 10_000);
 
         assert_eq!(wm.window_start_for(0), 0);
         assert_eq!(wm.window_start_for(9_999), 0);
         assert_eq!(wm.window_start_for(10_000), 10_000);
 
         // Watermark advances from 15_000 to 35_000
-        // Window [0, 30_000) closes at wm=30_000 (was open at 15_000)
+        // Window (0, 30_000] closes at wm=30_000 (was open at 15_000)
         let closed = wm.closed_windows(15_000, 35_000);
         assert_eq!(closed, vec![0]);
     }
@@ -191,48 +258,57 @@ mod tests {
     #[test]
     fn test_window_starts_containing_tumbling() {
         // 60s tumbling windows — each sample belongs to exactly one window
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
         let mut starts = wm.window_starts_containing(15_000);
         starts.sort();
         assert_eq!(starts, vec![0]);
 
         let mut starts = wm.window_starts_containing(60_000);
         starts.sort();
-        assert_eq!(starts, vec![60_000]);
+        assert_eq!(starts, vec![0]);
     }
 
     #[test]
     fn test_window_starts_containing_sliding() {
         // 30s window, 10s slide — each sample belongs to 3 windows
-        let wm = WindowManager::new(30_000, 10_000);
+        let wm = open_closed_manager(30_000, 10_000);
 
-        // t=15_000 belongs to [0, 30_000), [10_000, 40_000)
-        // and [-10_000, 20_000) which starts negative — still returned
+        // t=15_000 belongs to (0, 30_000], (10_000, 40_000]
+        // and (-10_000, 20_000] which starts negative — still returned
         let mut starts = wm.window_starts_containing(15_000);
         starts.sort();
         assert_eq!(starts, vec![-10_000, 0, 10_000]);
 
-        // t=30_000 belongs to [10_000, 40_000), [20_000, 50_000), [30_000, 60_000)
+        // The right endpoint is included and the left endpoint is excluded:
+        // t=30_000 belongs to (0, 30_000], (10_000, 40_000], (20_000, 50_000].
         let mut starts = wm.window_starts_containing(30_000);
         starts.sort();
-        assert_eq!(starts, vec![10_000, 20_000, 30_000]);
+        assert_eq!(starts, vec![0, 10_000, 20_000]);
     }
 
     // --- Pane method tests ---
 
     #[test]
-    fn test_pane_start_for_equals_window_start_for() {
-        // Pane start and window start use the same slide-aligned grid
-        let wm = WindowManager::new(30_000, 10_000);
-        for ts in [0, 5_000, 9_999, 10_000, 15_000, 25_000, 30_000] {
+    fn test_open_closed_pane_ownership_at_grid_boundaries() {
+        let wm = open_closed_manager(30_000, 10_000);
+
+        // Timestamp zero is the agreed nonnegative-origin exception.
+        assert_eq!(wm.pane_start_for(0), 0);
+
+        // Non-boundary samples retain ordinary floor alignment.
+        for ts in [5_000, 9_999, 15_000, 25_000] {
             assert_eq!(wm.pane_start_for(ts), wm.window_start_for(ts));
         }
+
+        // Exact boundaries belong to the pane ending at that timestamp.
+        assert_eq!(wm.pane_start_for(10_000), 0);
+        assert_eq!(wm.pane_start_for(30_000), 20_000);
     }
 
     #[test]
     fn test_panes_for_window_sliding() {
         // 30s window, 10s slide → 3 panes per window
-        let wm = WindowManager::new(30_000, 10_000);
+        let wm = open_closed_manager(30_000, 10_000);
 
         assert_eq!(wm.panes_for_window(0), vec![0, 10_000, 20_000]);
         assert_eq!(wm.panes_for_window(10_000), vec![10_000, 20_000, 30_000]);
@@ -242,7 +318,7 @@ mod tests {
     #[test]
     fn test_panes_for_window_tumbling_degeneration() {
         // 60s tumbling window → 1 pane per window (no merges needed)
-        let wm = WindowManager::new(60_000, 0);
+        let wm = open_closed_manager(60_000, 0);
 
         assert_eq!(wm.panes_for_window(0), vec![0]);
         assert_eq!(wm.panes_for_window(60_000), vec![60_000]);
@@ -250,30 +326,30 @@ mod tests {
 
     #[test]
     fn test_slide_interval_ms_accessor() {
-        let wm_tumbling = WindowManager::new(60_000, 0);
+        let wm_tumbling = open_closed_manager(60_000, 0);
         assert_eq!(wm_tumbling.slide_interval_ms(), 60_000);
 
-        let wm_sliding = WindowManager::new(30_000, 10_000);
+        let wm_sliding = open_closed_manager(30_000, 10_000);
         assert_eq!(wm_sliding.slide_interval_ms(), 10_000);
     }
 
     #[test]
     fn test_panes_for_window_count() {
         // W = window_size / slide_interval
-        let wm = WindowManager::new(30_000, 10_000);
+        let wm = open_closed_manager(30_000, 10_000);
         assert_eq!(wm.panes_for_window(0).len(), 3); // 30/10 = 3
 
-        let wm2 = WindowManager::new(50_000, 10_000);
+        let wm2 = open_closed_manager(50_000, 10_000);
         assert_eq!(wm2.panes_for_window(0).len(), 5); // 50/10 = 5
 
-        let wm3 = WindowManager::new(60_000, 0);
+        let wm3 = open_closed_manager(60_000, 0);
         assert_eq!(wm3.panes_for_window(0).len(), 1); // tumbling = 1
     }
 
     #[test]
     fn test_consecutive_windows_share_panes() {
         // 30s window, 10s slide — consecutive windows share W-1 = 2 panes
-        let wm = WindowManager::new(30_000, 10_000);
+        let wm = open_closed_manager(30_000, 10_000);
 
         let panes_a = wm.panes_for_window(0); // [0, 10_000, 20_000]
         let panes_b = wm.panes_for_window(10_000); // [10_000, 20_000, 30_000]

--- a/asap-query-engine/src/precompute_engine/worker.rs
+++ b/asap-query-engine/src/precompute_engine/worker.rs
@@ -5,7 +5,7 @@ use crate::precompute_engine::accumulator_factory::{
 use crate::precompute_engine::config::LateDataPolicy;
 use crate::precompute_engine::output_sink::OutputSink;
 use crate::precompute_engine::series_router::WorkerMessage;
-use crate::precompute_engine::window_manager::WindowManager;
+use crate::precompute_engine::window_manager::{WindowBoundary, WindowManager, WindowManagerError};
 use crate::precompute_operators::delta_set_aggregator_accumulator::DeltaSetAggregatorAccumulator;
 use crate::precompute_operators::sum_accumulator::SumAccumulator;
 use asap_types::aggregation_config::AggregationConfig;
@@ -235,7 +235,7 @@ impl Worker {
                         warn!("Worker {} final flush error: {}", self.id, e);
                     }
                     // Force-close any windows still open after the final flush.
-                    // `flush_all` only advances the watermark by +1ms (plus the
+                    // `flush_all` only follows observed event time (plus the
                     // wall-clock fallback, whose grace may not have elapsed for a
                     // one-shot batch), so the trailing window can remain open and
                     // its data would never reach the store. No more samples will
@@ -272,18 +272,20 @@ impl Worker {
                                 }
                                 // Force-close all open windows; no new samples will arrive
                                 // for this removed agg_id. Advance to a *finite* bound
-                                // (`max_pane + window_size_ms`), NOT `i64::MAX`:
+                                // (`max_pane + window_size_ms + 1`), NOT `i64::MAX`:
                                 // `closed_windows` enumerates window starts one slide at a
                                 // time, so `i64::MAX` would loop ~`i64::MAX / slide` times
                                 // and overflow (see `force_close_all`).
                                 let mut active_panes = state.active_panes;
                                 let closed = match active_panes.keys().next_back() {
                                     Some(&max_pane) => {
-                                        let force_wm = max_pane
-                                            .saturating_add(state.window_manager.window_size_ms());
-                                        state
-                                            .window_manager
-                                            .closed_windows(state.previous_watermark_ms, force_wm)
+                                        let force_wm_ms = max_pane
+                                            .saturating_add(state.window_manager.window_size_ms())
+                                            .saturating_add(1);
+                                        state.window_manager.closed_windows(
+                                            state.previous_watermark_ms,
+                                            force_wm_ms,
+                                        )
                                     }
                                     None => Vec::new(), // no open panes
                                 };
@@ -374,7 +376,7 @@ impl Worker {
         &mut self,
         agg_id: u64,
         group_key: &str,
-    ) -> Option<&mut GroupState> {
+    ) -> Result<Option<&mut GroupState>, WindowManagerError> {
         // Fast path: group already exists — borrow-based lookup, no allocation.
         let exists = self
             .group_states
@@ -382,9 +384,15 @@ impl Worker {
             .is_some_and(|m| m.contains_key(group_key));
         if !exists {
             // Creation path: requires a config, and allocates the interned key once.
-            let config = Arc::clone(self.agg_configs.get(&agg_id)?);
+            let Some(config) = self.agg_configs.get(&agg_id).map(Arc::clone) else {
+                return Ok(None);
+            };
             let gs = GroupState {
-                window_manager: WindowManager::new(config.window_size_ms, config.slide_interval_ms),
+                window_manager: WindowManager::new(
+                    config.window_size_ms,
+                    config.slide_interval_ms,
+                    WindowBoundary::OpenClosed,
+                )?,
                 config,
                 active_panes: BTreeMap::new(),
                 delta_set_previous_keys: HashSet::new(),
@@ -398,7 +406,10 @@ impl Worker {
             self.group_count
                 .store(self.total_groups(), Ordering::Relaxed);
         }
-        self.group_states.get_mut(&agg_id)?.get_mut(group_key)
+        Ok(self
+            .group_states
+            .get_mut(&agg_id)
+            .and_then(|groups| groups.get_mut(group_key)))
     }
 
     /// Process a batch of samples for a specific (agg_id, group_key).
@@ -418,7 +429,7 @@ impl Worker {
         // on `self`); used to stamp each pane's birth time below.
         let now_ms = (self.now_ms_fn)();
 
-        let state = match self.get_or_create_group_state(agg_id, group_key) {
+        let state = match self.get_or_create_group_state(agg_id, group_key)? {
             Some(state) => state,
             None => {
                 warn!(
@@ -435,7 +446,7 @@ impl Worker {
             .map(|(_, ts, _)| *ts)
             .max()
             .unwrap_or(i64::MIN);
-        let batch_min_ts = samples
+        let batch_min_ms = samples
             .iter()
             .map(|(_, ts, _)| *ts)
             .min()
@@ -446,11 +457,12 @@ impl Worker {
         } else {
             previous_wm
         };
-        // On the first batch there is no prior watermark. Use the earliest
-        // sample as the closure baseline so a batch spanning multiple windows
-        // can close windows older than that sample after all samples are routed.
+        // On the first batch there is no prior watermark. Place the closure
+        // baseline one millisecond before the earliest sample so a batch that
+        // spans multiple windows can close every window strictly before its
+        // maximum timestamp.
         let closure_previous_wm = if previous_wm == i64::MIN {
-            batch_min_ts
+            batch_min_ms.saturating_sub(1)
         } else {
             previous_wm
         };
@@ -473,14 +485,14 @@ impl Worker {
 
             // Check if pane was already evicted (late data for a closed window)
             if !state.active_panes.contains_key(&pane_start)
-                && previous_wm >= pane_start + state.window_manager.window_size_ms()
+                && previous_wm > pane_start + state.window_manager.window_size_ms()
             {
                 let window_start = pane_start;
                 let window_end = pane_start + state.window_manager.window_size_ms();
                 match late_data_policy {
                     LateDataPolicy::Drop => {
                         debug!(
-                            "Dropping late sample for evicted pane [{}, {})",
+                            "Dropping late sample for evicted pane ({}, {}]",
                             pane_start, pane_end
                         );
                         continue;
@@ -489,7 +501,7 @@ impl Worker {
                         if state.config.aggregation_type == AggregationType::DeltaSetAggregator =>
                     {
                         warn!(
-                            "Dropping late DeltaSetAggregator sample for evicted pane [{}, {}): ForwardToStore is unsupported for stateful key deltas",
+                            "Dropping late DeltaSetAggregator sample for evicted pane ({}, {}]: ForwardToStore is unsupported for stateful key deltas",
                             pane_start,
                             pane_end
                         );
@@ -507,7 +519,7 @@ impl Worker {
                         );
                         emit_batch.push((output, updater.take_accumulator()));
                         debug!(
-                            "Forwarding late sample to store for evicted pane [{}, {})",
+                            "Forwarding late sample to store for evicted pane ({}, {}]",
                             pane_start, pane_end
                         );
                         continue;
@@ -650,20 +662,22 @@ impl Worker {
                     continue; // No samples received yet — no panes to close.
                 }
 
-                // Effective watermark: max(group's own, global) + 1ms for boundary.
-                let propagated_wm = if global_wm != i64::MIN {
+                // Effective watermark: the largest observed event time. Do not
+                // synthesize a +1ms advance here: for `(start, end]` panes, a
+                // separately delivered sample at `end` must remain writable.
+                let propagated_wm_ms = if global_wm != i64::MIN {
                     state.previous_watermark_ms.max(global_wm)
                 } else {
                     state.previous_watermark_ms
                 };
-                let mut effective_wm = propagated_wm.saturating_add(1);
+                let mut effective_wm_ms = propagated_wm_ms;
 
                 // Wall-clock fallback for stuck event-time. If every sample
                 // carries the same timestamp (e.g. a one-shot batch where
                 // all records fall in the same second), `previous_watermark_ms`
-                // freezes and `closed_windows(prev, prev+1)` returns empty
+                // freezes, so ordinary event-time closure cannot make progress.
                 // forever — the window never closes and the store stays empty
-                // even though data has been ingested. Force `effective_wm`
+                // even though data has been ingested. Force `effective_wm_ms`
                 // past `pane_start + window_size_ms` for any pane that has
                 // gone *idle* — untouched by a sample — for `window_size +
                 // grace` of WALL-CLOCK time. This deliberately does NOT
@@ -677,9 +691,10 @@ impl Worker {
                     let window_size_ms = state.window_manager.window_size_ms();
                     for (&pane_start, &pane_last_touch_ms) in &state.pane_wall_clock_last_touch_ms {
                         if now_ms.saturating_sub(pane_last_touch_ms) >= window_size_ms + grace_ms {
-                            let force_to = pane_start.saturating_add(window_size_ms);
-                            if force_to > effective_wm {
-                                effective_wm = force_to;
+                            let forced_watermark_ms =
+                                pane_start.saturating_add(window_size_ms).saturating_add(1);
+                            if forced_watermark_ms > effective_wm_ms {
+                                effective_wm_ms = forced_watermark_ms;
                             }
                         }
                     }
@@ -687,7 +702,7 @@ impl Worker {
 
                 let closed = state
                     .window_manager
-                    .closed_windows(state.previous_watermark_ms, effective_wm);
+                    .closed_windows(state.previous_watermark_ms, effective_wm_ms);
 
                 for window_start in &closed {
                     let (_, window_end) = state.window_manager.window_bounds(*window_start);
@@ -714,10 +729,10 @@ impl Worker {
 
                 // Update group watermark to reflect the advancement.
                 // Monotonic advance — never retreat. Both the event-time
-                // boundary `propagated_wm + 1` and the wall-clock fallback
-                // only push `effective_wm` forward, so this is safe.
-                if effective_wm > state.previous_watermark_ms {
-                    state.previous_watermark_ms = effective_wm;
+                // propagated event time and the wall-clock fallback only push
+                // `effective_wm_ms` forward, so this is safe.
+                if effective_wm_ms > state.previous_watermark_ms {
+                    state.previous_watermark_ms = effective_wm_ms;
                 }
 
                 state.prune_pane_wall_clock_last_touch();
@@ -738,8 +753,8 @@ impl Worker {
 
     /// Force-close every window still open on shutdown.
     ///
-    /// Unlike `flush_all` — which only advances the watermark by `+1ms` (plus
-    /// the wall-clock fallback, gated on grace having elapsed) — this emits the
+    /// Unlike `flush_all` — which only follows observed event time (plus the
+    /// wall-clock fallback, gated on grace having elapsed) — this emits the
     /// window for every remaining pane unconditionally, because no further
     /// samples will arrive once the engine is shutting down. Without it, a
     /// one-shot batch whose records all fall in a single window (so event-time
@@ -747,7 +762,7 @@ impl Worker {
     /// and never write it to the store.
     ///
     /// To advance past the open windows we use a *finite* bound derived from
-    /// the largest open pane (`max_pane + window_size_ms`) rather than
+    /// the largest open pane (`max_pane + window_size_ms + 1`) rather than
     /// `i64::MAX`: `WindowManager::closed_windows` enumerates window starts up
     /// to `current_wm` one slide at a time, so passing `i64::MAX` would loop
     /// ~`i64::MAX / slide` times and overflow. `max_pane + window_size_ms` is
@@ -768,15 +783,17 @@ impl Worker {
                     continue; // never received data — nothing to close
                 }
                 // The latest window start equals the largest open pane start;
-                // closing window `[start, start + size)` needs `wm >= start + size`.
+                // closing window `(start, start + size]` needs `wm > start + size`.
                 let Some(&max_pane) = state.active_panes.keys().next_back() else {
                     continue; // no open panes
                 };
-                let force_wm = max_pane.saturating_add(state.window_manager.window_size_ms());
+                let force_wm_ms = max_pane
+                    .saturating_add(state.window_manager.window_size_ms())
+                    .saturating_add(1);
 
                 let closed = state
                     .window_manager
-                    .closed_windows(state.previous_watermark_ms, force_wm);
+                    .closed_windows(state.previous_watermark_ms, force_wm_ms);
 
                 for window_start in &closed {
                     let (_, window_end) = state.window_manager.window_bounds(*window_start);
@@ -801,8 +818,8 @@ impl Worker {
                     }
                 }
 
-                if force_wm > state.previous_watermark_ms {
-                    state.previous_watermark_ms = force_wm;
+                if force_wm_ms > state.previous_watermark_ms {
+                    state.previous_watermark_ms = force_wm_ms;
                 }
                 state.prune_pane_wall_clock_last_touch();
             }
@@ -1290,7 +1307,7 @@ mod tests {
         );
 
         // Two samples, same srcip, DIFFERENT dstip, IDENTICAL wire value
-        // (pkt_len). Window [0, 1000).
+        // (pkt_len). Window (0, 1000].
         worker
             .process_group_samples(
                 4,
@@ -1310,7 +1327,7 @@ mod tests {
             )
             .unwrap();
 
-        // Advance the watermark past the window end to close [0, 1000).
+        // Advance the watermark past the window end to close (0, 1000].
         worker
             .process_group_samples(
                 4,
@@ -1327,7 +1344,7 @@ mod tests {
         let (_output, acc) = captured
             .iter()
             .find(|(o, _)| o.start_timestamp == 0)
-            .expect("window [0, 1000) should emit a closed HLL pane");
+            .expect("window (0, 1000] should emit a closed HLL pane");
         let hll = acc
             .as_any()
             .downcast_ref::<HllAccumulator>()
@@ -1510,7 +1527,7 @@ mod tests {
         let (_output, acc) = captured
             .iter()
             .find(|(output, _)| output.start_timestamp == 0)
-            .expect("worker should emit the closed [0, 1000) window");
+            .expect("worker should emit the closed (0, 1000] window");
         let cms = acc
             .as_any()
             .downcast_ref::<CountMinSketchAccumulator>()
@@ -1579,7 +1596,7 @@ mod tests {
             LateDataPolicy::Drop,
         );
 
-        // Samples in window [0, 10000ms): sum should be 1+2+3=6.
+        // Samples in window (0, 10000ms]: sum should be 1+2+3+100=106.
         // All go to the same group (agg_id=1, group_key="")
         worker
             .process_group_samples(1, "", group_samples("cpu", vec![(1000, 1.0)]))
@@ -1592,9 +1609,12 @@ mod tests {
             .unwrap();
         assert_eq!(sink.len(), 0);
 
-        // Sample at t=10000ms closes [0, 10000)
+        // Sample at t=10000ms belongs to (0, 10000]. A later timestamp closes it.
         worker
             .process_group_samples(1, "", group_samples("cpu", vec![(10000, 100.0)]))
+            .unwrap();
+        worker
+            .process_group_samples(1, "", group_samples("cpu", vec![(10001, 0.0)]))
             .unwrap();
 
         let captured = sink.drain();
@@ -1610,10 +1630,91 @@ mod tests {
             .downcast_ref::<SumAccumulator>()
             .expect("should be SumAccumulator");
         assert!(
-            (sum_acc.sum - 6.0).abs() < 1e-10,
-            "sum should be 1+2+3=6, got {}",
+            (sum_acc.sum - 106.0).abs() < 1e-10,
+            "sum should include the right-endpoint sample (1+2+3+100=106), got {}",
             sum_acc.sum
         );
+    }
+
+    /// With `(start, end]` semantics, samples at `end` remain writable until
+    /// observed event time advances past `end`, so separately delivered
+    /// endpoint samples cannot be dropped.
+    #[test]
+    fn first_batch_boundary_sample_waits_for_watermark_to_advance() {
+        let config = make_agg_config(
+            20,
+            "cpu",
+            AggregationType::SingleSubpopulation,
+            "Sum",
+            1_000,
+            0,
+            vec![],
+        );
+        let sink = Arc::new(CapturingOutputSink::new());
+        let mut worker = make_worker(
+            arc_configs(HashMap::from([(20, config)])),
+            sink.clone(),
+            false,
+            0,
+            LateDataPolicy::Drop,
+        );
+
+        worker
+            .process_group_samples(20, "", group_samples("cpu", vec![(1_000, 7.0)]))
+            .unwrap();
+
+        assert_eq!(sink.len(), 0, "endpoint remains writable");
+        worker
+            .process_group_samples(20, "", group_samples("cpu", vec![(1_001, 0.0)]))
+            .unwrap();
+
+        let captured = sink.drain();
+        assert_eq!(captured.len(), 1);
+        let (output, accumulator) = &captured[0];
+        assert_eq!((output.start_timestamp, output.end_timestamp), (0, 1_000));
+        let sum = accumulator
+            .as_any()
+            .downcast_ref::<SumAccumulator>()
+            .expect("sum config should emit SumAccumulator");
+        assert_eq!(sum.sum, 7.0);
+    }
+
+    #[test]
+    fn timestamp_zero_uses_the_nonnegative_origin_window() {
+        let config = make_agg_config(
+            21,
+            "cpu",
+            AggregationType::SingleSubpopulation,
+            "Sum",
+            1_000,
+            0,
+            vec![],
+        );
+        let sink = Arc::new(CapturingOutputSink::new());
+        let mut worker = make_worker(
+            arc_configs(HashMap::from([(21, config)])),
+            sink.clone(),
+            false,
+            0,
+            LateDataPolicy::Drop,
+        );
+
+        worker
+            .process_group_samples(21, "", group_samples("cpu", vec![(0, 7.0)]))
+            .unwrap();
+        worker
+            .process_group_samples(21, "", group_samples("cpu", vec![(1_001, 0.0)]))
+            .unwrap();
+
+        let captured = sink.drain();
+        assert_eq!(captured.len(), 1);
+        let (output, accumulator) = &captured[0];
+        assert_eq!((output.start_timestamp, output.end_timestamp), (0, 1_000));
+        let sum = accumulator
+            .as_any()
+            .downcast_ref::<SumAccumulator>()
+            .expect("sum config should emit SumAccumulator");
+        assert_eq!(sum.sum, 7.0);
     }
 
     #[test]
@@ -1649,7 +1750,7 @@ mod tests {
         worker
             .process_group_samples(2, "", vec![("cpu{host=\"b\"}".to_string(), 1_000, 1.0)])
             .unwrap();
-
+        worker.force_close_all().unwrap();
         let first_window = sink
             .drain()
             .into_iter()
@@ -1661,13 +1762,19 @@ mod tests {
             .downcast_ref::<DeltaSetAggregatorAccumulator>()
             .expect("first output should be DeltaSetAggregatorAccumulator");
         let key_a = KeyByLabelValues::new_with_labels(vec!["a".to_string()]);
+        let key_b = KeyByLabelValues::new_with_labels(vec!["b".to_string()]);
         assert!(first_delta.added.contains(&key_a));
+        assert!(first_delta.added.contains(&key_b));
         assert!(first_delta.removed.is_empty());
 
         worker
             .process_group_samples(2, "", vec![("cpu{host=\"b\"}".to_string(), 2_000, 1.0)])
             .unwrap();
+        worker
+            .process_group_samples(2, "", vec![("cpu{host=\"c\"}".to_string(), 2_001, 1.0)])
+            .unwrap();
 
+        worker.force_close_all().unwrap();
         let second_window = sink
             .drain()
             .into_iter()
@@ -1678,8 +1785,7 @@ mod tests {
             .as_any()
             .downcast_ref::<DeltaSetAggregatorAccumulator>()
             .expect("second output should be DeltaSetAggregatorAccumulator");
-        let key_b = KeyByLabelValues::new_with_labels(vec!["b".to_string()]);
-        assert!(second_delta.added.contains(&key_b));
+        assert!(second_delta.added.is_empty());
         assert!(second_delta.removed.contains(&key_a));
     }
 
@@ -1729,6 +1835,9 @@ mod tests {
         // Close the window
         worker
             .process_group_samples(1, "", group_samples("cpu{host=\"A\"}", vec![(10000, 0.0)]))
+            .unwrap();
+        worker
+            .process_group_samples(1, "", group_samples("cpu{host=\"A\"}", vec![(10001, 0.0)]))
             .unwrap();
 
         let captured = sink.drain();
@@ -1793,7 +1902,6 @@ mod tests {
                 group_samples("cpu{pattern=\"sine\"}", vec![(2000, 7.0)]),
             )
             .unwrap();
-
         // Close both groups' windows
         worker
             .process_group_samples(
@@ -1810,6 +1918,7 @@ mod tests {
             )
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 2, "two groups → two outputs");
 
@@ -1890,6 +1999,7 @@ mod tests {
             )
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1, "one KLL output for the whole group");
 
@@ -1901,8 +2011,8 @@ mod tests {
             .expect("should be KLL");
         assert_eq!(
             kll.inner.count(),
-            3,
-            "KLL should contain all 3 series' samples"
+            4,
+            "KLL should contain all 3 interior samples plus the right endpoint"
         );
     }
 
@@ -1941,7 +2051,7 @@ mod tests {
         assert_eq!(sink.len(), 0);
 
         // Sample at t=45000ms → advances watermark to 45000ms
-        // Closes windows [0, 30000) and [10000, 40000)
+        // Closes windows (0, 30000] and (10000, 40000].
         worker
             .process_group_samples(2, "", group_samples("cpu", vec![(45_000, 0.0)]))
             .unwrap();
@@ -2020,6 +2130,7 @@ mod tests {
             .process_group_samples(3, "", group_samples("cpu{host=\"A\"}", vec![(10000, 0.0)]))
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(
             captured.len(),
@@ -2103,7 +2214,7 @@ mod tests {
             )
             .unwrap();
 
-        // Close the window [0, 10000).
+        // Close the window (0, 10000].
         worker
             .process_group_samples(
                 5,
@@ -2112,6 +2223,7 @@ mod tests {
             )
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1, "one group → one output");
 
@@ -2204,6 +2316,7 @@ mod tests {
             )
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1, "expected one closed window output");
 
@@ -2265,6 +2378,7 @@ mod tests {
             .process_group_samples(12, "", group_samples("latency", vec![(10_000, 0.0)]))
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1, "expected one closed window output");
 
@@ -2274,7 +2388,7 @@ mod tests {
             .downcast_ref::<DatasketchesKLLAccumulator>()
             .expect("hand-crafted engine should emit DatasketchesKLLAccumulator");
 
-        let arroyo_precompute_bytes = KllSketch::aggregate_kll(20, &[10.0, 20.0, 30.0])
+        let arroyo_precompute_bytes = KllSketch::aggregate_kll(20, &[10.0, 20.0, 30.0, 0.0])
             .expect("Arroyo KLL aggregation should produce bytes");
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
@@ -2371,6 +2485,7 @@ mod tests {
             )
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1, "expected one closed window output");
 
@@ -2709,6 +2824,7 @@ aggregations:
             .process_group_samples(10, "", group_samples("requests_total", vec![(10_000, 0.0)]))
             .unwrap();
 
+        worker.force_close_all().unwrap();
         let captured = sink.drain();
         assert_eq!(captured.len(), 1);
 
@@ -2794,11 +2910,11 @@ aggregations:
         let sink = Arc::new(CapturingOutputSink::new());
         let mut worker = make_worker(agg_configs, sink.clone(), false, 0, LateDataPolicy::Drop);
 
-        // Group A: send sample at t=5s (within window [0, 10s))
+        // Group A: send sample at t=5s (within window (0, 10s])
         worker
             .process_group_samples(1, "groupA", group_samples("cpu", vec![(5_000, 1.0)]))
             .unwrap();
-        // Group B: send sample at t=5s (within window [0, 10s))
+        // Group B: send sample at t=5s (within window (0, 10s])
         worker
             .process_group_samples(1, "groupB", group_samples("cpu", vec![(5_000, 2.0)]))
             .unwrap();
@@ -2815,7 +2931,7 @@ aggregations:
         worker.flush_all().unwrap();
         let flushed = sink.drain();
 
-        // Group B's window [0, 10s) should now be closed via propagation.
+        // Group B's window (0, 10s] should now be closed via propagation.
         let group_b_outputs: Vec<_> = flushed
             .iter()
             .filter(|(out, _)| {
@@ -3039,7 +3155,7 @@ aggregations:
         })
         .await
         .unwrap();
-        // t=10_000 closes window [0, 10_000).
+        // t=10_000 belongs to and closes window (0, 10_000].
         tx.send(WorkerMessage::GroupSamples {
             agg_id: 1,
             group_key: String::new(),
@@ -3053,17 +3169,13 @@ aggregations:
         handle.await.unwrap();
 
         let mut captured = sink.drain();
-        // Two windows close:
-        //  1. [0, 10_000) — closed inline when the t=10_000 sample advanced
-        //     the watermark; contains only the post-update t=5_000 sample.
-        //  2. [10_000, 20_000) — left open by the watermark but force-closed on
-        //     shutdown; contains the t=10_000 sample. Before the shutdown
-        //     force-close this trailing window was silently lost.
+        // One window closes: (0, 10_000] contains both post-update samples and
+        // closes inline when the right-endpoint sample advances the watermark.
         captured.sort_by_key(|(o, _)| o.start_timestamp);
         assert_eq!(
             captured.len(),
-            2,
-            "window [0,10_000) closes inline; [10_000,20_000) force-closes on shutdown"
+            1,
+            "window (0,10_000] should close inline with its endpoint sample"
         );
 
         let (output, acc) = &captured[0];
@@ -3076,26 +3188,11 @@ aggregations:
             .downcast_ref::<SumAccumulator>()
             .expect("should be SumAccumulator");
         // Pre-update sample (t=1000, val=1.0) was dropped — agg_id was unknown.
-        // Post-update sample (t=5000, val=2.0) is the only one in this window.
+        // The endpoint sample is zero, so the post-update sum remains 2.0.
         assert!(
             (sum_acc.sum - 2.0).abs() < 1e-10,
             "only post-update sample should be aggregated, got {}",
             sum_acc.sum
-        );
-
-        // The trailing window force-closed on shutdown holds the t=10_000
-        // sample (val=0.0).
-        let (trailing_output, trailing_acc) = &captured[1];
-        assert_eq!(trailing_output.start_timestamp, 10_000);
-        assert_eq!(trailing_output.end_timestamp, 20_000);
-        let trailing_sum = trailing_acc
-            .as_any()
-            .downcast_ref::<SumAccumulator>()
-            .expect("should be SumAccumulator");
-        assert!(
-            trailing_sum.sum.abs() < 1e-10,
-            "trailing window should hold the t=10_000 sample (val=0.0), got {}",
-            trailing_sum.sum
         );
     }
 
@@ -3152,12 +3249,12 @@ aggregations:
         );
         let handle = tokio::spawn(async move { worker.run().await });
 
-        // Open a window at a large epoch-ms timestamp; nothing advances the
+        // Open a window just after a large epoch-ms boundary; nothing advances the
         // watermark past it, so it's still open when the agg_id is removed.
         tx.send(WorkerMessage::GroupSamples {
             agg_id: 1,
             group_key: String::new(),
-            samples: vec![("cpu".to_string(), base_ms, 7.0)],
+            samples: vec![("cpu".to_string(), base_ms + 1, 7.0)],
             ingest_received_at: std::time::Instant::now(),
         })
         .await
@@ -3200,7 +3297,7 @@ aggregations:
     //
     // Reproduces the one-shot-batch failure mode: every record falls in the
     // same window and no later timestamp ever arrives to advance the
-    // watermark, so `flush_all`'s `+1ms` event-time advance is a no-op and the
+    // watermark, so an ordinary `flush_all` leaves the window open and the
     // window never closes — the store stays empty. The wall-clock fallback
     // force-closes the pane once it has been alive for `window_size + grace`
     // of wall-clock time. Uses an injected fake clock so it runs in
@@ -3223,15 +3320,8 @@ aggregations:
             arc_configs(agg_configs),
             WorkerRuntimeConfig {
                 max_buffer_per_series: 10_000,
-                // 1, not 0: every flush_all() call unconditionally nudges the
-                // event-time watermark forward by 1ms (the "+1ms boundary
-                // advance" that lets an idle stream make progress),
-                // independent of the wall-clock fallback these tests target.
-                // A test that calls flush_all() and then processes another
-                // same-timestamp touch would otherwise have that 1ms of
-                // drift alone mark the touch "late" and drop it via a wholly
-                // different code path. 1ms is the exact amount one
-                // intervening flush contributes, not an arbitrary buffer.
+                // Keep a small lateness allowance so this test isolates the
+                // wall-clock fallback rather than late-data handling.
                 allowed_lateness_ms: 1,
                 pass_raw_samples: false,
                 raw_mode_aggregation_id: 0,
@@ -3467,7 +3557,7 @@ aggregations:
         let sink = Arc::new(CapturingOutputSink::new());
         let mut worker = make_worker_with_grace(agg_configs, sink.clone(), 0);
 
-        // All samples land in window [0, 10_000); the watermark freezes below
+        // All samples land in window (0, 10_000]; the watermark freezes below
         // the window end because no later timestamp ever arrives.
         for i in 0..5 {
             worker

--- a/asap-query-engine/tests/e2e_precompute_equivalence.rs
+++ b/asap-query-engine/tests/e2e_precompute_equivalence.rs
@@ -169,6 +169,91 @@ fn gzip_hex(bytes: &[u8]) -> String {
     hex::encode(encoder.finish().unwrap())
 }
 
+struct PromqlPrecomputeFixture<'a> {
+    port: u16,
+    metric: &'a str,
+    query: &'a str,
+    aggregation_configs: Vec<AggregationConfig>,
+    schema_labels: Vec<String>,
+    samples: Vec<TimeSeries>,
+    evaluation_time_seconds: f64,
+    base_interval_ms: u64,
+}
+
+impl PromqlPrecomputeFixture<'_> {
+    async fn run(self) -> QueryResult {
+        let aggregation_ids: Vec<u64> = self
+            .aggregation_configs
+            .iter()
+            .map(|config| config.aggregation_id)
+            .collect();
+        let streaming_config = Arc::new(StreamingConfig::new(
+            self.aggregation_configs
+                .into_iter()
+                .map(|config| (config.aggregation_id, config))
+                .collect(),
+        ));
+        let sink = Arc::new(CapturingOutputSink::new());
+        let engine = PrecomputeEngine::new(
+            engine_config(),
+            streaming_config.clone(),
+            sink.clone(),
+            vec![Box::new(HttpIngestSource::new(HttpIngestConfig {
+                port: self.port,
+            }))],
+        );
+        tokio::spawn(async move {
+            let _ = engine.run().await;
+        });
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+        let client = reqwest::Client::new();
+        for sample in self.samples {
+            send_remote_write(&client, self.port, vec![sample]).await;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+
+        let store = Arc::new(SimpleMapStore::new(
+            streaming_config.clone(),
+            CleanupPolicy::NoCleanup,
+        ));
+        for (output, accumulator) in sink.drain() {
+            store
+                .insert_precomputed_output(output, accumulator)
+                .unwrap();
+        }
+
+        let query_config = aggregation_ids.into_iter().fold(
+            QueryConfig::new(self.query.to_string()),
+            |config, aggregation_id| {
+                config.add_aggregation(AggregationReference::new(aggregation_id, None))
+            },
+        );
+        let inference_config = InferenceConfig {
+            schema: SchemaConfig::PromQL(PromQLSchema::new().add_metric(
+                self.metric.to_string(),
+                promql_utilities::data_model::key_by_label_names::KeyByLabelNames::new(
+                    self.schema_labels,
+                ),
+            )),
+            query_configs: vec![query_config],
+            cleanup_policy: CleanupPolicy::NoCleanup,
+        };
+        let query_engine = SimpleEngine::new(
+            store,
+            inference_config,
+            streaming_config,
+            self.base_interval_ms,
+            QueryLanguage::promql,
+        );
+
+        query_engine
+            .handle_query_promql(self.query.to_string(), self.evaluation_time_seconds)
+            .unwrap_or_else(|| panic!("precomputed query should succeed: {}", self.query))
+            .1
+    }
+}
+
 // ─── test 1: DatasketchesKLL output matches wire-format KLL ─────────────────
 
 /// Full e2e: send KLL samples through the HTTP ingest → PrecomputeEngine stack,
@@ -477,4 +562,243 @@ async fn e2e_sliding_precompute_outputs_compose_a_wider_query() {
 
     assert_eq!(vector.values.len(), 1);
     assert_eq!(vector.values[0].value, 45.0);
+}
+
+/// Regression for #698: PromQL evaluates a range at `T` over
+/// `(T - range, T]`. The sample exactly at the lower bound must be excluded,
+/// the sample at `T` must be included, and a sample after `T` must not leak
+/// into the result even when it has already been ingested.
+#[tokio::test]
+async fn e2e_promql_sum_uses_open_closed_evaluation_window() {
+    let port = 19403u16;
+    let agg_id = 4u64;
+    let window_size_ms = 1_000u64;
+    let metric = "data";
+    let query = "sum(data)";
+
+    let config = make_agg_config(
+        agg_id,
+        metric,
+        AggregationType::Sum,
+        "",
+        window_size_ms,
+        0,
+        vec![],
+    );
+    let samples = [
+        (1_000, 100.0),   // excluded lower bound
+        (1_500, 2.0),     // included interior
+        (2_000, 3.0),     // included evaluation endpoint
+        (2_500, 1_000.0), // excluded future sample
+        (3_500, 0.0),     // advance the watermark so every relevant window closes
+    ]
+    .into_iter()
+    .map(|(timestamp_ms, value)| make_timeseries(metric, vec![], timestamp_ms, value))
+    .collect();
+    let result = PromqlPrecomputeFixture {
+        port,
+        metric,
+        query,
+        aggregation_configs: vec![config],
+        schema_labels: vec![],
+        samples,
+        evaluation_time_seconds: 2.0,
+        base_interval_ms: window_size_ms,
+    }
+    .run()
+    .await;
+    let QueryResult::Vector(vector) = result else {
+        panic!("expected instant vector result");
+    };
+
+    assert_eq!(vector.values.len(), 1);
+    assert_eq!(vector.values[0].value, 5.0);
+}
+
+/// The #698 boundary contract applies independently to a query's value and
+/// key precomputes. An endpoint series can only appear when both sides assign
+/// its sample to the window ending at the evaluation timestamp.
+#[tokio::test]
+async fn e2e_promql_count_uses_open_closed_value_and_key_windows() {
+    let port = 19404u16;
+    let value_agg_id = 5u64;
+    let key_agg_id = 6u64;
+    let window_size_ms = 1_000u64;
+    let metric = "events";
+    let query = "count(events) by (host)";
+
+    let mut value_config = make_agg_config_full(
+        value_agg_id,
+        metric,
+        AggregationType::CountMinSketch,
+        "count",
+        window_size_ms,
+        0,
+        vec![],
+        vec!["host"],
+    );
+    value_config
+        .parameters
+        .insert("depth".to_string(), json!(3_u64));
+    value_config
+        .parameters
+        .insert("width".to_string(), json!(128_u64));
+    let key_config = make_agg_config_full(
+        key_agg_id,
+        metric,
+        AggregationType::SetAggregator,
+        "",
+        window_size_ms,
+        0,
+        vec![],
+        vec!["host"],
+    );
+    let samples = [
+        (1_000, "lower"),
+        (1_500, "interior"),
+        (2_000, "endpoint"),
+        (2_500, "future"),
+        (3_500, "watermark"),
+    ]
+    .into_iter()
+    .map(|(timestamp_ms, host)| make_timeseries(metric, vec![("host", host)], timestamp_ms, 1.0))
+    .collect();
+    let result = PromqlPrecomputeFixture {
+        port,
+        metric,
+        query,
+        aggregation_configs: vec![value_config, key_config],
+        schema_labels: vec!["host".to_string()],
+        samples,
+        evaluation_time_seconds: 2.0,
+        base_interval_ms: window_size_ms,
+    }
+    .run()
+    .await;
+    let QueryResult::Vector(vector) = result else {
+        panic!("expected instant vector result");
+    };
+    let returned: HashMap<String, f64> = vector
+        .values
+        .into_iter()
+        .map(|element| {
+            (
+                element
+                    .labels
+                    .labels
+                    .last()
+                    .expect("host label should be present")
+                    .clone(),
+                element.value,
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        returned,
+        HashMap::from([("interior".to_string(), 1.0), ("endpoint".to_string(), 1.0)])
+    );
+}
+
+/// Temporal selectors use the same `(T - range, T]` ownership as ordinary
+/// instant-vector aggregations. Using q=1 makes either leaked boundary value
+/// unmistakable in the result.
+#[tokio::test]
+async fn e2e_quantile_over_time_uses_open_closed_evaluation_window() {
+    let port = 19405u16;
+    let agg_id = 7u64;
+    let window_size_ms = 1_000u64;
+    let metric = "latency";
+    let query = "quantile_over_time(1.0, latency[1s])";
+
+    let mut config = make_agg_config(
+        agg_id,
+        metric,
+        AggregationType::DatasketchesKLL,
+        "",
+        window_size_ms,
+        0,
+        vec![],
+    );
+    config.parameters.insert("K".to_string(), json!(200_u64));
+    let samples = [
+        (1_000, 100.0),
+        (1_500, 2.0),
+        (2_000, 4.0),
+        (2_500, 1_000.0),
+        (3_500, 0.0),
+    ]
+    .into_iter()
+    .map(|(timestamp_ms, value)| make_timeseries(metric, vec![], timestamp_ms, value))
+    .collect();
+    let result = PromqlPrecomputeFixture {
+        port,
+        metric,
+        query,
+        aggregation_configs: vec![config],
+        schema_labels: vec![],
+        samples,
+        evaluation_time_seconds: 2.0,
+        base_interval_ms: window_size_ms,
+    }
+    .run()
+    .await;
+    let QueryResult::Vector(vector) = result else {
+        panic!("expected instant vector result");
+    };
+
+    assert_eq!(vector.values.len(), 1);
+    assert_eq!(vector.values[0].value, 4.0);
+}
+
+/// Sliding precomputes keep their existing exact-cover composition while
+/// samples on every slide boundary move to the pane ending at that boundary.
+/// The shared 6s boundary must be counted once, not once per stored window.
+#[tokio::test]
+async fn e2e_sliding_query_uses_open_closed_boundaries_without_double_counting() {
+    let port = 19406u16;
+    let agg_id = 8u64;
+    let window_size_ms = 5_000u64;
+    let slide_interval_ms = 1_000u64;
+    let metric = "sliding_data";
+    let query = "sum_over_time(sliding_data[10s])";
+
+    let config = make_agg_config(
+        agg_id,
+        metric,
+        AggregationType::Sum,
+        "",
+        window_size_ms,
+        slide_interval_ms,
+        vec![],
+    );
+    let samples = [
+        (1_000, 100.0),    // excluded lower bound
+        (2_000, 2.0),      // first stored window
+        (6_000, 3.0),      // shared boundary, included only in the first window
+        (11_000, 5.0),     // included evaluation endpoint
+        (12_000, 1_000.0), // excluded future sample
+        (20_000, 0.0),     // close all relevant windows
+    ]
+    .into_iter()
+    .map(|(timestamp_ms, value)| make_timeseries(metric, vec![], timestamp_ms, value))
+    .collect();
+    let result = PromqlPrecomputeFixture {
+        port,
+        metric,
+        query,
+        aggregation_configs: vec![config],
+        schema_labels: vec![],
+        samples,
+        evaluation_time_seconds: 11.0,
+        base_interval_ms: slide_interval_ms,
+    }
+    .run()
+    .await;
+    let QueryResult::Vector(vector) = result else {
+        panic!("expected instant vector result");
+    };
+
+    assert_eq!(vector.values.len(), 1);
+    assert_eq!(vector.values[0].value, 10.0);
 }


### PR DESCRIPTION
## Summary
- Store precompute panes with open-left, closed-right ownership so PromQL evaluation windows use (T-R, T].
- Add a four-case WindowBoundary enum, supporting OpenClosed now.
- Cover values, keys, quantiles, sliding windows, endpoint batching, and timestamp-zero origin behavior.

## Testing
- cargo test -p query_engine_rust --all-targets
- cargo test after rebasing onto main

Rebased onto the latest main, including the planner test fix.