### PR TITLE
fix(planner,query-engine): recognize topk over temporal aggregations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sql_utilities",
+ "thiserror 1.0.69",
  "tracing",
 ]
 

--- a/asap-common/dependencies/rs/asap_types/Cargo.toml
+++ b/asap-common/dependencies/rs/asap_types/Cargo.toml
@@ -12,4 +12,5 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 anyhow.workspace = true
+thiserror.workspace = true
 clap.workspace = true

--- a/asap-common/dependencies/rs/asap_types/src/aggregation_config.rs
+++ b/asap-common/dependencies/rs/asap_types/src/aggregation_config.rs
@@ -9,6 +9,25 @@ use crate::utils::normalize_spatial_filter;
 use promql_utilities::data_model::KeyByLabelNames;
 use promql_utilities::query_logics::enums::AggregationType;
 
+#[derive(Debug, thiserror::Error)]
+pub enum AggregationConfigError {
+    #[error(
+        "aggregation {aggregation_id} (CountMinSketchWithHeap) missing required parameter 'count_events'"
+    )]
+    MissingCountEvents { aggregation_id: u64 },
+    #[error(
+        "aggregation {aggregation_id} (CountMinSketchWithHeap) parameter 'count_events' must be a boolean, got {value}"
+    )]
+    InvalidCountEventsType { aggregation_id: u64, value: Value },
+    #[error(
+        "aggregation {aggregation_id} ({aggregation_type}) parameter 'count_events' is only valid for CountMinSketchWithHeap"
+    )]
+    MisplacedCountEvents {
+        aggregation_id: u64,
+        aggregation_type: AggregationType,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AggregationConfig {
     pub aggregation_id: u64,
@@ -49,6 +68,31 @@ pub struct AggregationIdInfo {
 // TODO: need to implement deserialization methods
 
 impl AggregationConfig {
+    pub fn validate(&self) -> Result<(), AggregationConfigError> {
+        if self.aggregation_type == AggregationType::CountMinSketchWithHeap {
+            match self.parameters.get("count_events") {
+                None => {
+                    return Err(AggregationConfigError::MissingCountEvents {
+                        aggregation_id: self.aggregation_id,
+                    })
+                }
+                Some(value) if !value.is_boolean() => {
+                    return Err(AggregationConfigError::InvalidCountEventsType {
+                        aggregation_id: self.aggregation_id,
+                        value: value.clone(),
+                    })
+                }
+                Some(_) => {}
+            }
+        } else if self.parameters.contains_key("count_events") {
+            return Err(AggregationConfigError::MisplacedCountEvents {
+                aggregation_id: self.aggregation_id,
+                aggregation_type: self.aggregation_type,
+            });
+        }
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         aggregation_id: u64,
@@ -177,7 +221,7 @@ impl AggregationConfig {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        Ok(Self::new(
+        let config = Self::new(
             aggregation_id,
             aggregation_type,
             aggregation_sub_type,
@@ -195,7 +239,9 @@ impl AggregationConfig {
             read_count_threshold,
             table_name,
             value_column,
-        ))
+        );
+        config.validate()?;
+        Ok(config)
     }
 
     pub fn deserialize_from_bytes(
@@ -323,7 +369,7 @@ impl AggregationConfig {
             }
         };
 
-        Ok(Self::new(
+        let config = Self::new(
             aggregation_id,
             aggregation_type,
             aggregation_sub_type,
@@ -341,7 +387,9 @@ impl AggregationConfig {
             read_count_threshold,
             table_name,
             value_column,
-        ))
+        );
+        config.validate()?;
+        Ok(config)
     }
 }
 

--- a/asap-common/dependencies/rs/asap_types/src/capability_matching.rs
+++ b/asap-common/dependencies/rs/asap_types/src/capability_matching.rs
@@ -5,11 +5,19 @@ use promql_utilities::data_model::KeyByLabelNames;
 use promql_utilities::query_logics::enums::Statistic;
 use tracing::{debug, warn};
 
-use crate::aggregation_config::{AggregationConfig, AggregationIdInfo};
+use crate::aggregation_config::{AggregationConfig, AggregationConfigError, AggregationIdInfo};
 use crate::enums::WindowType;
 use crate::query_requirements::QueryRequirements;
 use crate::utils::normalize_spatial_filter;
 use promql_utilities::query_logics::enums::AggregationType;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CapabilityMatchingError {
+    #[error(transparent)]
+    InvalidAggregationConfig(#[from] AggregationConfigError),
+    #[error("top-k query requirements must specify count_events weighting")]
+    MissingTopkWeighting,
+}
 
 // ---------------------------------------------------------------------------
 // Pure compatibility helpers
@@ -158,15 +166,14 @@ pub fn spatial_filter_compatible(config_filter: &str, req_filter: &str) -> bool 
     config_norm == req_norm
 }
 
-/// Reads the `count_events` parameter from a `CountMinSketchWithHeap` config.
-/// Defaults to `true` (COUNT semantics) so existing count top-k configs that
-/// omit the flag keep matching COUNT top-k queries.
+/// Reads the required `count_events` parameter from a validated
+/// `CountMinSketchWithHeap` config.
 fn config_count_events(config: &AggregationConfig) -> bool {
     config
         .parameters
         .get("count_events")
         .and_then(|v| v.as_bool())
-        .unwrap_or(true)
+        .expect("aggregation configs are validated before capability matching")
 }
 
 /// Top-k weighting compatibility. Only constrains `Statistic::Topk` candidates;
@@ -221,7 +228,8 @@ pub fn aggregation_priority(a: &AggregationConfig, b: &AggregationConfig) -> Ord
 /// Find a compatible aggregation (or pair of aggregations for multi-population queries)
 /// given all available aggregation configs and a set of query requirements.
 ///
-/// Returns `None` if no fully compatible match exists.
+/// Returns `Ok(None)` if no fully compatible match exists and `Err` if any
+/// aggregation config is malformed.
 ///
 /// Algorithm:
 /// 1. For each statistic, collect and sort compatible candidates.
@@ -232,9 +240,21 @@ pub fn aggregation_priority(a: &AggregationConfig, b: &AggregationConfig) -> Ord
 pub fn find_compatible_aggregation(
     configs: &HashMap<u64, AggregationConfig>,
     requirements: &QueryRequirements,
-) -> Option<AggregationIdInfo> {
+) -> Result<Option<AggregationIdInfo>, CapabilityMatchingError> {
+    if requirements.statistics.contains(&Statistic::Topk)
+        && requirements.topk_count_events.is_none()
+    {
+        return Err(CapabilityMatchingError::MissingTopkWeighting);
+    }
+
+    let mut configs_by_id: Vec<&AggregationConfig> = configs.values().collect();
+    configs_by_id.sort_by_key(|config| config.aggregation_id);
+    for config in configs_by_id {
+        config.validate()?;
+    }
+
     if requirements.statistics.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     debug!(
@@ -289,7 +309,7 @@ pub fn find_compatible_aggregation(
                 statistic = ?stat,
                 "capability matching: no compatible aggregation found for statistic",
             );
-            return None;
+            return Ok(None);
         }
 
         debug!(
@@ -321,7 +341,7 @@ pub fn find_compatible_aggregation(
                 required_window_size_ms = value_agg.window_size_ms,
                 "capability matching: no matching window/labels for multi-statistic requirement",
             );
-            return None;
+            return Ok(None);
         }
     }
 
@@ -364,7 +384,10 @@ pub fn find_compatible_aggregation(
                 ),
             }
         }
-        ka?
+        let Some(ka) = ka else {
+            return Ok(None);
+        };
+        ka
     } else {
         value_agg
     };
@@ -378,12 +401,12 @@ pub fn find_compatible_aggregation(
         "capability matching: resolved",
     );
 
-    Some(AggregationIdInfo {
+    Ok(Some(AggregationIdInfo {
         aggregation_id_for_value: value_agg.aggregation_id,
         aggregation_type_for_value: value_agg.aggregation_type,
         aggregation_id_for_key: key_agg.aggregation_id,
         aggregation_type_for_key: key_agg.aggregation_type,
-    })
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -396,6 +419,16 @@ mod tests {
     use crate::utils::normalize_spatial_filter;
     use promql_utilities::data_model::KeyByLabelNames;
     use std::collections::HashMap;
+
+    /// Existing matching tests exercise valid configurations and keep their
+    /// Option-focused assertions; an unexpected validation error should fail them.
+    fn find_compatible_aggregation(
+        configs: &HashMap<u64, AggregationConfig>,
+        requirements: &QueryRequirements,
+    ) -> Option<AggregationIdInfo> {
+        super::find_compatible_aggregation(configs, requirements)
+            .expect("test aggregation configs should be valid")
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn make_config(
@@ -411,7 +444,7 @@ mod tests {
         let grouping_labels =
             KeyByLabelNames::new(grouping.iter().map(|s| s.to_string()).collect());
         let spatial_filter_normalized = normalize_spatial_filter(spatial_filter);
-        AggregationConfig {
+        let mut config = AggregationConfig {
             aggregation_id: id,
             aggregation_type: agg_type.parse::<AggregationType>().expect("valid agg type"),
             aggregation_sub_type: sub_type.to_string(),
@@ -430,7 +463,13 @@ mod tests {
             read_count_threshold: None,
             table_name: None,
             value_column: None,
+        };
+        if config.aggregation_type == AggregationType::CountMinSketchWithHeap {
+            config
+                .parameters
+                .insert("count_events".to_string(), serde_json::Value::Bool(true));
         }
+        config
     }
 
     fn req(
@@ -448,6 +487,16 @@ mod tests {
             spatial_filter_normalized: normalize_spatial_filter(spatial_filter),
             topk_count_events: None,
         }
+    }
+
+    fn topk_req_with_range(
+        metric: &str,
+        data_range_ms: u64,
+        count_events: Option<bool>,
+    ) -> QueryRequirements {
+        let mut requirements = req(metric, &[Statistic::Topk], data_range_ms, &[], "");
+        requirements.topk_count_events = count_events;
+        requirements
     }
 
     fn assert_key_compatibility_cases(
@@ -976,10 +1025,8 @@ mod tests {
                 "",
             ),
         );
-        let result = find_compatible_aggregation(
-            &configs,
-            &req("req", &[Statistic::Topk], 300_000, &[], ""),
-        );
+        let result =
+            find_compatible_aggregation(&configs, &topk_req_with_range("req", 300_000, Some(true)));
         let info = result.unwrap();
         assert_eq!(info.aggregation_id_for_value, 10);
         assert_eq!(info.aggregation_id_for_key, 11);
@@ -998,10 +1045,8 @@ mod tests {
             &[],
             "",
         ));
-        let result = find_compatible_aggregation(
-            &configs,
-            &req("req", &[Statistic::Topk], 300_000, &[], ""),
-        );
+        let result =
+            find_compatible_aggregation(&configs, &topk_req_with_range("req", 300_000, Some(true)));
         assert!(result.is_none());
     }
 
@@ -1137,10 +1182,8 @@ mod tests {
                 "",
             ),
         );
-        let result = find_compatible_aggregation(
-            &configs,
-            &req("req", &[Statistic::Topk], 300_000, &[], ""),
-        );
+        let result =
+            find_compatible_aggregation(&configs, &topk_req_with_range("req", 300_000, Some(true)));
         assert!(
             result.is_none(),
             "a Sliding DeltaSetAggregator must never be selected as the paired key agg"
@@ -1169,10 +1212,8 @@ mod tests {
             11,
             make_config(11, "req", "SetAggregator", "", 300_000, "sliding", &[], ""),
         );
-        let result = find_compatible_aggregation(
-            &configs,
-            &req("req", &[Statistic::Topk], 300_000, &[], ""),
-        );
+        let result =
+            find_compatible_aggregation(&configs, &topk_req_with_range("req", 300_000, Some(true)));
         let info =
             result.expect("Sliding SetAggregator on the value aggregation's grid must be accepted");
         assert_eq!(info.aggregation_id_for_key, 11);
@@ -1573,9 +1614,7 @@ mod tests {
     }
 
     fn topk_req(metric: &str, count_events: Option<bool>) -> QueryRequirements {
-        let mut r = req(metric, &[Statistic::Topk], 1_000, &[], "");
-        r.topk_count_events = count_events;
-        r
+        topk_req_with_range(metric, 1_000, count_events)
     }
 
     #[test]
@@ -1621,38 +1660,44 @@ mod tests {
     }
 
     #[test]
-    fn topk_count_query_matches_sketch_without_explicit_flag() {
-        // Configs that omit `count_events` default to count semantics, so a
-        // COUNT top-k query still matches (backwards compatibility).
+    fn topk_matching_rejects_sketch_without_count_events() {
+        // A missing weighting flag is malformed configuration, not implicit
+        // COUNT semantics. Capability matching must distinguish it from a miss.
         let mut configs = HashMap::new();
-        configs.insert(
+        let mut malformed = make_config(
             7,
-            make_config(
-                7,
-                "netflow_table",
-                "CountMinSketchWithHeap",
-                "",
-                1_000,
-                "tumbling",
-                &[],
-                "",
-            ),
+            "netflow_table",
+            "CountMinSketchWithHeap",
+            "",
+            1_000,
+            "tumbling",
+            &[],
+            "",
         );
+        malformed.parameters.remove("count_events");
+        configs.insert(7, malformed);
         configs.insert(9, make_key_agg(9, "netflow_table"));
-        let result = find_compatible_aggregation(&configs, &topk_req("netflow_table", Some(true)))
-            .expect("default (no flag) sketch should serve COUNT top-k");
-        assert_eq!(result.aggregation_id_for_value, 7);
+        let error =
+            super::find_compatible_aggregation(&configs, &topk_req("netflow_table", Some(true)))
+                .expect_err("missing count_events must be a capability-matching error");
+        assert!(matches!(
+            error,
+            CapabilityMatchingError::InvalidAggregationConfig(
+                AggregationConfigError::MissingCountEvents { aggregation_id: 7 }
+            )
+        ));
     }
 
     #[test]
-    fn topk_unconstrained_weighting_matches_any_sketch() {
-        // `topk_count_events: None` (e.g. PromQL top-k) imposes no weighting
-        // constraint, so any heap sketch on the metric matches.
+    fn topk_without_weighting_is_rejected_as_ambiguous() {
         let mut configs = HashMap::new();
         configs.insert(3, make_topk_config(3, "netflow_table", false));
         configs.insert(9, make_key_agg(9, "netflow_table"));
-        let result = find_compatible_aggregation(&configs, &topk_req("netflow_table", None))
-            .expect("unconstrained top-k should match regardless of count_events");
-        assert_eq!(result.aggregation_id_for_value, 3);
+        let error = super::find_compatible_aggregation(&configs, &topk_req("netflow_table", None))
+            .expect_err("top-k without an explicit weighting must be rejected");
+        assert!(matches!(
+            error,
+            CapabilityMatchingError::MissingTopkWeighting
+        ));
     }
 }

--- a/asap-common/dependencies/rs/asap_types/src/query_requirements.rs
+++ b/asap-common/dependencies/rs/asap_types/src/query_requirements.rs
@@ -32,8 +32,8 @@ pub struct QueryRequirements {
     ///   * `Some(true)`  → COUNT semantics (`count_events: true`, weight 1/event),
     ///   * `Some(false)` → SUM semantics (`count_events: false`, weight = value).
     ///
-    /// `None` for non-top-k requirements (and for PromQL top-k, which does not
-    /// constrain the sketch weighting); matching ignores it when `None`.
+    /// PromQL top-k is value-weighted, so it uses `Some(false)`. `None` is only
+    /// valid for non-top-k requirements.
     pub topk_count_events: Option<bool>,
 }
 
@@ -91,12 +91,14 @@ pub fn build_query_requirements_promql(
         all_labels
     };
 
+    let topk_count_events = statistics.contains(&Statistic::Topk).then_some(false);
+
     Some(QueryRequirements {
         metric,
         statistics,
         data_range_ms,
         grouping_labels,
         spatial_filter_normalized: normalize_spatial_filter(&spatial_filter),
-        topk_count_events: None,
+        topk_count_events,
     })
 }

--- a/asap-common/dependencies/rs/asap_types/src/query_requirements.rs
+++ b/asap-common/dependencies/rs/asap_types/src/query_requirements.rs
@@ -1,6 +1,7 @@
 use promql_utilities::ast_matching::PromQLMatchResult;
 use promql_utilities::data_model::KeyByLabelNames;
 use promql_utilities::query_logics::enums::Statistic;
+use promql_utilities::query_logics::logics::promql_topk_count_events;
 use promql_utilities::query_logics::parsing::{
     get_metric_and_spatial_filter, get_spatial_aggregation_output_labels, get_statistics_to_compute,
 };
@@ -32,8 +33,9 @@ pub struct QueryRequirements {
     ///   * `Some(true)`  → COUNT semantics (`count_events: true`, weight 1/event),
     ///   * `Some(false)` → SUM semantics (`count_events: false`, weight = value).
     ///
-    /// PromQL top-k is value-weighted, so it uses `Some(false)`. `None` is only
-    /// valid for non-top-k requirements.
+    /// PromQL top-k over a raw vector or `sum_over_time` is value-weighted
+    /// (`Some(false)`); over `count_over_time` it is count-weighted
+    /// (`Some(true)`). `None` is only valid for non-top-k requirements.
     pub topk_count_events: Option<bool>,
 }
 
@@ -91,7 +93,7 @@ pub fn build_query_requirements_promql(
         all_labels
     };
 
-    let topk_count_events = statistics.contains(&Statistic::Topk).then_some(false);
+    let topk_count_events = promql_topk_count_events(match_result);
 
     Some(QueryRequirements {
         metric,

--- a/asap-common/dependencies/rs/asap_types/src/streaming_config.rs
+++ b/asap-common/dependencies/rs/asap_types/src/streaming_config.rs
@@ -7,7 +7,9 @@ use std::io::BufReader;
 use std::ops::Index;
 
 use crate::aggregation_config::{AggregationConfig, AggregationIdInfo};
-use crate::capability_matching::find_compatible_aggregation as common_find_compatible;
+use crate::capability_matching::{
+    find_compatible_aggregation as common_find_compatible, CapabilityMatchingError,
+};
 use crate::enums::QueryLanguage;
 use crate::inference_config::{InferenceConfig, SchemaConfig};
 use crate::query_requirements::QueryRequirements;
@@ -111,7 +113,7 @@ impl StreamingConfig {
     pub fn find_compatible_aggregation(
         &self,
         requirements: &QueryRequirements,
-    ) -> Option<AggregationIdInfo> {
+    ) -> Result<Option<AggregationIdInfo>, CapabilityMatchingError> {
         common_find_compatible(&self.aggregation_configs, requirements)
     }
 }
@@ -127,5 +129,114 @@ impl Index<u64> for StreamingConfig {
 impl Default for StreamingConfig {
     fn default() -> Self {
         Self::new(HashMap::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aggregation_config::AggregationConfigError;
+
+    #[test]
+    fn rejects_heap_config_without_count_events() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+aggregations:
+  - aggregationId: 1
+    aggregationType: CountMinSketchWithHeap
+    aggregationSubType: topk
+    parameters:
+      depth: 3
+      width: 1024
+      heapsize: 20
+    labels:
+      grouping: []
+      aggregated: [instance]
+      rollup: []
+    metric: http_requests_total
+    windowSizeMs: 15000
+    slideIntervalMs: 15000
+    windowType: tumbling
+    spatialFilter: ''
+"#,
+        )
+        .unwrap();
+
+        let error = StreamingConfig::from_yaml_data(&yaml, None)
+            .expect_err("heap config without count_events must be rejected");
+
+        assert!(matches!(
+            error.downcast_ref::<AggregationConfigError>(),
+            Some(AggregationConfigError::MissingCountEvents { aggregation_id: 1 })
+        ));
+    }
+
+    #[test]
+    fn rejects_heap_config_with_non_boolean_count_events() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+aggregations:
+  - aggregationId: 1
+    aggregationType: CountMinSketchWithHeap
+    aggregationSubType: topk
+    parameters:
+      depth: 3
+      width: 1024
+      heapsize: 20
+      count_events: "false"
+    labels:
+      grouping: []
+      aggregated: [instance]
+      rollup: []
+    metric: http_requests_total
+    windowSizeMs: 15000
+    slideIntervalMs: 15000
+    windowType: tumbling
+    spatialFilter: ''
+"#,
+        )
+        .unwrap();
+
+        let error = StreamingConfig::from_yaml_data(&yaml, None)
+            .expect_err("heap config with non-boolean count_events must be rejected");
+
+        assert!(error.to_string().contains("aggregation 1"));
+        assert!(error.to_string().contains("count_events"));
+        assert!(error.to_string().contains("boolean"));
+    }
+
+    #[test]
+    fn rejects_count_events_on_non_heap_config() {
+        let yaml: Value = serde_yaml::from_str(
+            r#"
+aggregations:
+  - aggregationId: 1
+    aggregationType: CountMinSketch
+    aggregationSubType: sum
+    parameters:
+      depth: 3
+      width: 1024
+      count_events: false
+    labels:
+      grouping: []
+      aggregated: [instance]
+      rollup: []
+    metric: http_requests_total
+    windowSizeMs: 15000
+    slideIntervalMs: 15000
+    windowType: tumbling
+    spatialFilter: ''
+"#,
+        )
+        .unwrap();
+
+        let error = StreamingConfig::from_yaml_data(&yaml, None)
+            .expect_err("count_events on a non-heap aggregation must be rejected");
+
+        assert!(error.to_string().contains("aggregation 1"));
+        assert!(error.to_string().contains("count_events"));
+        assert!(error
+            .to_string()
+            .contains("only valid for CountMinSketchWithHeap"));
     }
 }

--- a/asap-common/dependencies/rs/promql_utilities/src/query_logics/logics.rs
+++ b/asap-common/dependencies/rs/promql_utilities/src/query_logics/logics.rs
@@ -79,8 +79,14 @@ pub fn does_precompute_operator_support_subpopulations(
         // CountMinSketch supports subpopulations only for certain statistics
         AggregationType::CountMinSketch => matches!(statistic, Statistic::Sum | Statistic::Count),
 
-        // CountMinSketchWithHeap is only supported for Topk — does not support subpopulations
-        AggregationType::CountMinSketchWithHeap if matches!(statistic, Statistic::Topk) => false,
+        // CountMinSketchWithHeap (Topk) is a heavy-hitters sketch: one heap
+        // instance tracks many keys internally (like MultipleSum's HashMap),
+        // it just doesn't need an *external* paired key aggregation to
+        // enumerate them (unlike CountMinSketch/HydraKLL) -- it discovers its
+        // own top-k keys via CmsHeapItem. So it supports subpopulations the
+        // same way MultipleSum does: labels go in `aggregated`, not
+        // `grouping` (see `set_subpopulation_labels`).
+        AggregationType::CountMinSketchWithHeap if matches!(statistic, Statistic::Topk) => true,
 
         AggregationType::HLL => false,
 
@@ -203,6 +209,16 @@ mod tests {
         assert!(does_precompute_operator_support_subpopulations(
             Statistic::Sum,
             AggregationType::CountMinSketch,
+        ));
+
+        // CountMinSketchWithHeap (topk) is self-keyed but still tracks many
+        // keys internally -- the labels belong in `aggregated`, not
+        // `grouping` (#699 differential run: a planner regression here
+        // routed every sample to one degenerate empty key, producing
+        // `__name__="data",instance=""` with the real labels dropped).
+        assert!(does_precompute_operator_support_subpopulations(
+            Statistic::Topk,
+            AggregationType::CountMinSketchWithHeap,
         ));
     }
 

--- a/asap-common/dependencies/rs/promql_utilities/src/query_logics/logics.rs
+++ b/asap-common/dependencies/rs/promql_utilities/src/query_logics/logics.rs
@@ -107,7 +107,42 @@ pub fn get_is_collapsable(
         ),
         AggregationOperator::Min => temporal_aggregation == PromQLFunction::MinOverTime,
         AggregationOperator::Max => temporal_aggregation == PromQLFunction::MaxOverTime,
+        // topk ranks by whatever value the temporal function produces per
+        // series: sum_over_time's summed value or count_over_time's event
+        // count. See `Statistic::Topk`'s handling in `get_statistics_to_compute`
+        // and `promql_topk_count_events`, which derive from the same pairing.
+        AggregationOperator::Topk => matches!(
+            temporal_aggregation,
+            PromQLFunction::SumOverTime | PromQLFunction::CountOverTime
+        ),
         _ => false,
+    }
+}
+
+/// For a topk match result, the `count_events` weighting the wrapped temporal
+/// function implies:
+///   * no temporal function (raw vector topk), or `sum_over_time` → `Some(false)`
+///     (value-weighted: topk ranks by the value itself),
+///   * `count_over_time` → `Some(true)` (count-weighted: topk ranks by the
+///     per-series event count).
+///
+/// Returns `None` if the match result is not a topk aggregation.
+pub fn promql_topk_count_events(
+    match_result: &crate::ast_matching::PromQLMatchResult,
+) -> Option<bool> {
+    if match_result
+        .get_aggregation_op()?
+        .parse::<AggregationOperator>()
+        != Ok(AggregationOperator::Topk)
+    {
+        return None;
+    }
+    match match_result
+        .get_function_name()
+        .and_then(|name| name.parse::<PromQLFunction>().ok())
+    {
+        Some(PromQLFunction::CountOverTime) => Some(true),
+        _ => Some(false),
     }
 }
 

--- a/asap-common/dependencies/rs/promql_utilities/src/query_logics/parsing.rs
+++ b/asap-common/dependencies/rs/promql_utilities/src/query_logics/parsing.rs
@@ -84,11 +84,16 @@ pub fn get_metric_and_spatial_filter(match_result: &PromQLMatchResult) -> (Strin
 ///   reachable via a pattern already narrowed to a collapsable `(function,
 ///   op)` pair (see `get_is_collapsable`, and #508's pattern-narrowing fix
 ///   that makes non-collapsable combinations fail to match at all) — asserted
-///   below rather than silently trusted. The statistic still comes from the
-///   *function*, never the outer op: e.g. `count_over_time` + `sum` needs a
-///   `Count` accumulator, not a `Sum` one — summing per-series counts gives
-///   the group's total count, so the outer op only describes how per-series
-///   results combine, never which statistic must be precomputed.
+///   below rather than silently trusted. Which side supplies the statistic
+///   then depends on the outer op:
+///     - `topk`: the statistic is always `Topk` — a `topk(k, sum_over_time(x))`
+///       still needs a heavy-hitter sketch, not a `Sum` accumulator, so the
+///       outer op is never dropped (see #699).
+///     - every other collapsable op: the statistic comes from the *function*,
+///       never the outer op — e.g. `count_over_time` + `sum` needs a `Count`
+///       accumulator, not a `Sum` one, since summing per-series counts gives
+///       the group's total count. Here the outer op only describes how
+///       per-series results combine, never which statistic must be precomputed.
 ///
 /// Returns a typed error if the matched statistic/function name is not
 /// recognized, so callers can decide whether to skip or fail the query.
@@ -107,20 +112,23 @@ pub fn get_statistics_to_compute(
     };
 
     let statistic_to_compute: Option<String> = if has_function && has_aggregation {
+        let aggregation_op = match_result
+            .get_aggregation_op()
+            .and_then(|o| o.parse::<AggregationOperator>().ok());
         debug_assert!(
             match_result
                 .get_function_name()
                 .and_then(|f| f.parse::<PromQLFunction>().ok())
-                .zip(
-                    match_result
-                        .get_aggregation_op()
-                        .and_then(|o| o.parse::<AggregationOperator>().ok())
-                )
+                .zip(aggregation_op)
                 .is_some_and(|(f, o)| get_is_collapsable(f, o)),
             "a match with both function and aggregation tokens must be collapsable \
              (patterns are narrowed to only collapsable pairs, see #508)"
         );
-        function_statistic(match_result)
+        if aggregation_op == Some(AggregationOperator::Topk) {
+            Some(AggregationOperator::Topk.as_str().to_string())
+        } else {
+            function_statistic(match_result)
+        }
     } else if has_function {
         function_statistic(match_result)
     } else if has_aggregation {

--- a/asap-planner-rs/src/planner/patterns.rs
+++ b/asap-planner-rs/src/planner/patterns.rs
@@ -90,6 +90,7 @@ pub fn build_patterns() -> Vec<PromQLPattern> {
             AggregationOperator::Quantile,
             AggregationOperator::Min,
             AggregationOperator::Max,
+            AggregationOperator::Topk,
         ]
         .into_iter()
         .filter_map(move |op| {
@@ -131,10 +132,11 @@ mod tests {
     }
 
     #[test]
-    fn exactly_four_collapsable_one_temporal_one_spatial_patterns() {
-        // 2 ONLY_TEMPORAL + 1 ONLY_SPATIAL + 4 collapsable ONE_TEMPORAL_ONE_SPATIAL
-        // (sum+sum_over_time, sum+count_over_time, min+min_over_time, max+max_over_time).
-        assert_eq!(build_patterns().len(), 7);
+    fn exactly_six_collapsable_one_temporal_one_spatial_patterns() {
+        // 2 ONLY_TEMPORAL + 1 ONLY_SPATIAL + 6 collapsable ONE_TEMPORAL_ONE_SPATIAL
+        // (sum+sum_over_time, sum+count_over_time, min+min_over_time,
+        // max+max_over_time, topk+sum_over_time, topk+count_over_time).
+        assert_eq!(build_patterns().len(), 9);
     }
 
     #[test]
@@ -143,6 +145,10 @@ mod tests {
         assert!(matches_some_pattern("sum(count_over_time(x[5m]))"));
         assert!(matches_some_pattern("min(min_over_time(x[5m]))"));
         assert!(matches_some_pattern("max(max_over_time(x[5m]))"));
+        assert!(matches_some_pattern("topk(1, sum_over_time(x[5m]))"));
+        assert!(matches_some_pattern(
+            "topk by (job) (3, count_over_time(x[5m]))"
+        ));
     }
 
     #[test]
@@ -162,6 +168,14 @@ mod tests {
         assert!(
             !matches_some_pattern("min(max_over_time(x[5m]))"),
             "min+max_over_time is not collapsable"
+        );
+        assert!(
+            !matches_some_pattern("topk(1, rate(x[5m]))"),
+            "topk+rate is not collapsable"
+        );
+        assert!(
+            !matches_some_pattern("topk(1, avg_over_time(x[5m]))"),
+            "topk+avg_over_time is not collapsable"
         );
     }
 }

--- a/asap-planner-rs/src/planner/sketch.rs
+++ b/asap-planner-rs/src/planner/sketch.rs
@@ -18,8 +18,7 @@ const DEFAULT_HLL_PRECISION: u64 = 14;
 /// `topk_k` is required for `CountMinSketchWithHeap`. PromQL supplies it from
 /// the `topk(k, …)` query argument; SQL supplies it from `LIMIT k`.
 ///
-/// `topk_count_events` disambiguates COUNT vs SUM SQL top-k (`true` / `false`).
-/// PromQL passes `None` and omits the parameter (defaults to count semantics).
+/// `topk_count_events` disambiguates event-count vs value-weighted top-k.
 pub fn build_sketch_parameters(
     aggregation_type: AggregationType,
     aggregation_sub_type: &str,
@@ -61,6 +60,9 @@ pub fn build_sketch_parameters(
             }
             let k = topk_k
                 .ok_or_else(|| "CountMinSketchWithHeap requires a topk k value".to_string())?;
+            let count_events = topk_count_events.ok_or_else(|| {
+                "CountMinSketchWithHeap requires explicit count_events weighting".to_string()
+            })?;
             let depth = sketch_params
                 .and_then(|p| p.count_min_sketch_with_heap.as_ref())
                 .map(|p| p.depth)
@@ -80,12 +82,10 @@ pub fn build_sketch_parameters(
                 "heapsize".to_string(),
                 serde_json::Value::Number((k * heap_mult).into()),
             );
-            if let Some(count_events) = topk_count_events {
-                m.insert(
-                    "count_events".to_string(),
-                    serde_json::Value::Bool(count_events),
-                );
-            }
+            m.insert(
+                "count_events".to_string(),
+                serde_json::Value::Bool(count_events),
+            );
             Ok(m)
         }
 
@@ -167,7 +167,7 @@ pub fn build_sketch_parameters_from_promql(
         aggregation_type,
         aggregation_sub_type,
         topk_k,
-        None,
+        Some(false),
         sketch_params,
     )
 }

--- a/asap-planner-rs/src/planner/sketch.rs
+++ b/asap-planner-rs/src/planner/sketch.rs
@@ -1,6 +1,7 @@
 use crate::config::input::SketchParameterOverrides;
 use promql_utilities::ast_matching::PromQLMatchResult;
 use promql_utilities::query_logics::enums::AggregationType;
+use promql_utilities::query_logics::logics::promql_topk_count_events;
 use std::collections::HashMap;
 
 // Default sketch parameters
@@ -163,11 +164,18 @@ pub fn build_sketch_parameters_from_promql(
     } else {
         None
     };
+    let topk_count_events = if aggregation_type == AggregationType::CountMinSketchWithHeap {
+        Some(promql_topk_count_events(match_result).ok_or_else(|| {
+            "topk query missing required aggregation match to derive count_events".to_string()
+        })?)
+    } else {
+        None
+    };
     build_sketch_parameters(
         aggregation_type,
         aggregation_sub_type,
         topk_k,
-        Some(false),
+        topk_count_events,
         sketch_params,
     )
 }

--- a/asap-planner-rs/tests/integration.rs
+++ b/asap-planner-rs/tests/integration.rs
@@ -464,6 +464,62 @@ fn topk_produces_count_min_sketch_with_heap() {
 }
 
 #[test]
+fn topk_over_sum_over_time_produces_value_weighted_heap() {
+    // https://github.com/ProjectASAP/asap-internal/issues/699 — topk wrapping
+    // a temporal aggregation must still be planned, not silently omitted.
+    let c = Controller::from_yaml_with_schema(
+        r#"
+query_groups:
+  - id: 1
+    queries:
+      - "topk(1, sum_over_time(http_requests_total[5m]))"
+    repetition_delay_ms: 60000
+    controller_options:
+      accuracy_sla: 0.99
+      latency_sla: 1.0
+"#,
+        http_requests_schema(),
+        arroyo_opts(),
+    )
+    .unwrap();
+    let out = c.generate().unwrap();
+    assert_eq!(out.inference_query_count(), 1);
+    assert!(out.has_aggregation_type("CountMinSketchWithHeap"));
+    assert_eq!(
+        out.aggregation_parameter("CountMinSketchWithHeap", "count_events"),
+        Some(serde_yaml::Value::Bool(false)),
+        "topk ranks the summed value, not the observation count"
+    );
+}
+
+#[test]
+fn topk_over_count_over_time_produces_count_weighted_heap() {
+    let c = Controller::from_yaml_with_schema(
+        r#"
+query_groups:
+  - id: 1
+    queries:
+      - "topk by (job) (3, count_over_time(http_requests_total[5m]))"
+    repetition_delay_ms: 60000
+    controller_options:
+      accuracy_sla: 0.99
+      latency_sla: 1.0
+"#,
+        http_requests_schema(),
+        arroyo_opts(),
+    )
+    .unwrap();
+    let out = c.generate().unwrap();
+    assert_eq!(out.inference_query_count(), 1);
+    assert!(out.has_aggregation_type("CountMinSketchWithHeap"));
+    assert_eq!(
+        out.aggregation_parameter("CountMinSketchWithHeap", "count_events"),
+        Some(serde_yaml::Value::Bool(true)),
+        "topk over count_over_time ranks the observation count"
+    );
+}
+
+#[test]
 fn heap_parameters_require_explicit_count_events_weighting() {
     let error = asap_planner::planner::sketch::build_sketch_parameters(
         AggregationType::CountMinSketchWithHeap,

--- a/asap-planner-rs/tests/integration.rs
+++ b/asap-planner-rs/tests/integration.rs
@@ -490,6 +490,31 @@ query_groups:
         Some(serde_yaml::Value::Bool(false)),
         "topk ranks the summed value, not the observation count"
     );
+    // The heap tracks per-key state internally (it's a heavy-hitters sketch,
+    // not a single running total), so ingest must build a real per-sample
+    // key from every schema label -- not route everything to one degenerate
+    // empty key. Regression test for the differential suite's observed
+    // `__name__="data",instance=""` (job dropped) output: the planner was
+    // putting the label set in `grouping` (routing-only, unused by a
+    // self-keyed sketch) instead of `aggregated` (the in-sketch key).
+    let mut aggregated = out.aggregation_labels("CountMinSketchWithHeap", "aggregated");
+    aggregated.sort();
+    let mut expected = vec![
+        "instance".to_string(),
+        "job".to_string(),
+        "method".to_string(),
+        "status".to_string(),
+    ];
+    expected.sort();
+    assert_eq!(
+        aggregated, expected,
+        "topk's heap must track every schema label as its in-sketch key"
+    );
+    assert!(
+        out.aggregation_labels("CountMinSketchWithHeap", "grouping")
+            .is_empty(),
+        "topk has one heap instance per query, not one per grouping-label combination"
+    );
 }
 
 #[test]

--- a/asap-planner-rs/tests/integration.rs
+++ b/asap-planner-rs/tests/integration.rs
@@ -1,5 +1,6 @@
 use asap_planner::{Controller, ControllerError, PromQLSchema, RuntimeOptions, StreamingEngine};
 use promql_utilities::data_model::KeyByLabelNames;
+use promql_utilities::query_logics::enums::AggregationType;
 use std::path::Path;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -455,6 +456,25 @@ fn topk_produces_count_min_sketch_with_heap() {
     .unwrap();
     let out = c.generate().unwrap();
     assert!(out.has_aggregation_type("CountMinSketchWithHeap"));
+    assert_eq!(
+        out.aggregation_parameter("CountMinSketchWithHeap", "count_events"),
+        Some(serde_yaml::Value::Bool(false)),
+        "PromQL topk ranks sample values, not observation counts"
+    );
+}
+
+#[test]
+fn heap_parameters_require_explicit_count_events_weighting() {
+    let error = asap_planner::planner::sketch::build_sketch_parameters(
+        AggregationType::CountMinSketchWithHeap,
+        "topk",
+        Some(5),
+        None,
+        None,
+    )
+    .expect_err("heap planning without count_events must be rejected");
+
+    assert!(error.contains("count_events"));
 }
 
 #[test]

--- a/asap-query-engine/src/engines/simple_engine/mod.rs
+++ b/asap-query-engine/src/engines/simple_engine/mod.rs
@@ -301,6 +301,7 @@ impl SimpleEngine {
                 AggregationOperator::Quantile,
                 AggregationOperator::Min,
                 AggregationOperator::Max,
+                AggregationOperator::Topk,
             ]
             .into_iter()
             .filter_map(move |op| {

--- a/asap-query-engine/src/engines/simple_engine/promql.rs
+++ b/asap-query-engine/src/engines/simple_engine/promql.rs
@@ -1453,6 +1453,47 @@ mod topk_pipeline_tests {
         assert_eq!(requirements.topk_count_events, Some(false));
     }
 
+    #[test]
+    fn topk_over_sum_over_time_matches_and_is_value_weighted() {
+        // https://github.com/ProjectASAP/asap-internal/issues/699
+        let (engine, _store) = build_topk_engine();
+        let query = "topk(1, sum_over_time(transfer_events[5m]))";
+        let ast = promql_parser::parser::parse(query).unwrap();
+        let match_result = engine
+            .find_matching_controller_pattern(&ast, query)
+            .expect("topk over sum_over_time should match a controller pattern");
+        let schema = PromQLSchema::new().add_metric(
+            METRIC.to_string(),
+            KeyByLabelNames::new(vec!["srcip".to_string()]),
+        );
+        let requirements =
+            asap_types::build_query_requirements_promql(query, &match_result, &schema, 1000)
+                .expect("topk over sum_over_time requirements should build");
+
+        assert_eq!(requirements.statistics, vec![Statistic::Topk]);
+        assert_eq!(requirements.topk_count_events, Some(false));
+    }
+
+    #[test]
+    fn topk_over_count_over_time_matches_and_is_count_weighted() {
+        let (engine, _store) = build_topk_engine();
+        let query = "topk by (job) (3, count_over_time(transfer_events[5m]))";
+        let ast = promql_parser::parser::parse(query).unwrap();
+        let match_result = engine
+            .find_matching_controller_pattern(&ast, query)
+            .expect("topk over count_over_time should match a controller pattern");
+        let schema = PromQLSchema::new().add_metric(
+            METRIC.to_string(),
+            KeyByLabelNames::new(vec!["srcip".to_string()]),
+        );
+        let requirements =
+            asap_types::build_query_requirements_promql(query, &match_result, &schema, 1000)
+                .expect("topk over count_over_time requirements should build");
+
+        assert_eq!(requirements.statistics, vec![Statistic::Topk]);
+        assert_eq!(requirements.topk_count_events, Some(true));
+    }
+
     fn build_topk_engine() -> (SimpleEngine, Arc<SimpleMapStore>) {
         let promql_schema = PromQLSchema::new().add_metric(
             METRIC.to_string(),

--- a/asap-query-engine/src/engines/simple_engine/promql.rs
+++ b/asap-query-engine/src/engines/simple_engine/promql.rs
@@ -1242,7 +1242,8 @@ impl SimpleEngine {
                 .read()
                 .unwrap()
                 .clone()
-                .find_compatible_aggregation(&requirements)?
+                .find_compatible_aggregation(&requirements)
+                .unwrap_or_else(|error| panic!("capability matching failed: {error}"))?
         };
 
         let result =
@@ -1433,6 +1434,24 @@ mod topk_pipeline_tests {
     // Aligned to the 1s scrape interval (multiple of 1000ms).
     const QUERY_TIME: f64 = 1_759_276_810.0;
     const TOPK_QUERY: &str = "topk(10, transfer_events)";
+
+    #[test]
+    fn promql_topk_requirements_are_explicitly_value_weighted() {
+        let (engine, _store) = build_topk_engine();
+        let ast = promql_parser::parser::parse(TOPK_QUERY).unwrap();
+        let match_result = engine
+            .find_matching_controller_pattern(&ast, TOPK_QUERY)
+            .expect("topk query should match");
+        let schema = PromQLSchema::new().add_metric(
+            METRIC.to_string(),
+            KeyByLabelNames::new(vec!["srcip".to_string()]),
+        );
+        let requirements =
+            asap_types::build_query_requirements_promql(TOPK_QUERY, &match_result, &schema, 1000)
+                .expect("topk requirements should build");
+
+        assert_eq!(requirements.topk_count_events, Some(false));
+    }
 
     fn build_topk_engine() -> (SimpleEngine, Arc<SimpleMapStore>) {
         let promql_schema = PromQLSchema::new().add_metric(

--- a/asap-query-engine/src/engines/simple_engine/sql.rs
+++ b/asap-query-engine/src/engines/simple_engine/sql.rs
@@ -501,7 +501,8 @@ impl SimpleEngine {
                 .read()
                 .unwrap()
                 .clone()
-                .find_compatible_aggregation(&requirements)?
+                .find_compatible_aggregation(&requirements)
+                .unwrap_or_else(|error| panic!("capability matching failed: {error}"))?
         };
         let metric = &match_result.outer_data()?.metric;
 
@@ -1484,17 +1485,14 @@ mod topk_pipeline_tests {
     }
 
     #[test]
-    fn count_topk_capability_fallback_defaults_count_events_true() {
-        // Heap omits `count_events`; matcher treats that as count semantics.
+    #[should_panic(
+        expected = "capability matching failed: aggregation 113 (CountMinSketchWithHeap) missing required parameter 'count_events'"
+    )]
+    fn count_topk_capability_fallback_rejects_missing_count_events() {
+        // Invalid weighting metadata must fail loudly instead of becoming a
+        // capability miss that could fall back to the source database.
         let engine = build_capability_fallback_engine(vec![make_heap_agg(HEAP_DEFAULT_ID, None)]);
-        let context = engine
-            .build_query_execution_context_sql(topk_query(10), QUERY_TIME)
-            .expect("COUNT top-k should match a sketch with default count_events");
-
-        assert_eq!(
-            context.agg_info.aggregation_id_for_value, HEAP_DEFAULT_ID,
-            "default (no flag) heap must serve COUNT top-k",
-        );
+        let _ = engine.build_query_execution_context_sql(topk_query(10), QUERY_TIME);
     }
 
     #[test]
@@ -1517,14 +1515,15 @@ mod topk_pipeline_tests {
     }
 
     #[test]
-    fn sum_topk_capability_fallback_rejects_count_only_default_heap() {
-        // Only a default (count-weighted) sketch exists; SUM top-k cannot be served.
-        let engine = build_capability_fallback_engine(vec![make_heap_agg(HEAP_DEFAULT_ID, None)]);
+    fn sum_topk_capability_fallback_rejects_explicit_count_only_heap() {
+        // Only an explicitly count-weighted sketch exists; SUM top-k cannot be served.
+        let engine =
+            build_capability_fallback_engine(vec![make_heap_agg(HEAP_DEFAULT_ID, Some(true))]);
         assert!(
             engine
                 .build_query_execution_context_sql(sum_topk_query(5), QUERY_TIME)
                 .is_none(),
-            "SUM top-k must not fall back to a count_events-default sketch",
+            "SUM top-k must not fall back to a count_events: true sketch",
         );
     }
 }

--- a/asap-query-engine/src/precompute_engine/accumulator_factory.rs
+++ b/asap-query-engine/src/precompute_engine/accumulator_factory.rs
@@ -905,18 +905,13 @@ fn cms_heap_params(config: &AggregationConfig) -> Result<(usize, usize, usize), 
     Ok((row_num, col_num, heap_size))
 }
 
-/// Whether a CountMinSketchWithHeap config should count events (weight 1 per
-/// observation, COUNT semantics) rather than summing the sample value.
-/// Defaults to `true` so `COUNT(...)` top-k works out of the box.
+/// Whether a validated CountMinSketchWithHeap config counts events (weight 1
+/// per observation) rather than summing the sample value.
 fn cms_count_events(config: &AggregationConfig) -> Result<bool, String> {
-    match config.parameters.get("count_events") {
-        None => Ok(true),
-        Some(value) => value.as_bool().ok_or_else(|| {
-            format!(
-                "CountMinSketchWithHeap parameter 'count_events' must be a boolean, got {value}"
-            )
-        }),
-    }
+    config.validate().map_err(|error| error.to_string())?;
+    Ok(config.parameters["count_events"]
+        .as_bool()
+        .expect("validation guarantees a boolean count_events parameter"))
 }
 
 /// Extract the HLL `precision` parameter from a config. Falls back to
@@ -953,6 +948,7 @@ fn hll_precision_param(config: &AggregationConfig) -> u32 {
 pub fn create_accumulator_updater(
     config: &AggregationConfig,
 ) -> Result<Box<dyn AccumulatorUpdater>, String> {
+    config.validate().map_err(|error| error.to_string())?;
     let sub_type = config.aggregation_sub_type.as_str();
 
     match config.aggregation_type {
@@ -1638,6 +1634,7 @@ mod tests {
         p.insert("depth".to_string(), serde_json::json!(3_u64));
         p.insert("width".to_string(), serde_json::json!(1024_u64));
         p.insert("heapsize".to_string(), serde_json::json!(32_u64));
+        p.insert("count_events".to_string(), serde_json::json!(true));
         p
     }
 
@@ -1748,7 +1745,7 @@ mod tests {
 
     #[test]
     fn test_cms_with_heap_count_events_uses_unit_weight() {
-        // count_events (the default) → each observation contributes weight 1, so
+        // count_events=true → each observation contributes weight 1, so
         // the per-key estimate is the EVENT COUNT, not the sum of sample values.
         let config = cms_heap_config(cms_heap_params_required());
         let mut updater = create_accumulator_updater(&config).unwrap();
@@ -1791,17 +1788,28 @@ mod tests {
     }
 
     #[test]
-    fn test_cms_heap_params_reads_depth_width_heapsize() {
+    fn test_cms_with_heap_factory_rejects_missing_count_events() {
         let mut params = std::collections::HashMap::new();
         params.insert("depth".to_string(), serde_json::json!(4));
         params.insert("width".to_string(), serde_json::json!(2048));
         params.insert("heapsize".to_string(), serde_json::json!(40));
         let config = cms_heap_config(params);
+        let error = create_accumulator_updater(&config)
+            .err()
+            .expect("missing count_events must be rejected");
+        assert!(error.contains("aggregation 101"));
+        assert!(error.contains("count_events"));
+    }
+
+    #[test]
+    fn test_cms_heap_params_reads_depth_width_heapsize() {
+        let mut params = cms_heap_params_required();
+        params.insert("depth".to_string(), serde_json::json!(4));
+        params.insert("width".to_string(), serde_json::json!(2048));
+        params.insert("heapsize".to_string(), serde_json::json!(40));
+        let config = cms_heap_config(params);
+
         assert_eq!(cms_heap_params(&config).unwrap(), (4, 2048, 40));
-        assert!(
-            cms_count_events(&config).unwrap(),
-            "count_events defaults to true"
-        );
     }
 
     #[test]

--- a/asap-query-engine/src/precompute_engine/engine.rs
+++ b/asap-query-engine/src/precompute_engine/engine.rs
@@ -368,6 +368,7 @@ mod tests {
         parameters.insert("depth".to_string(), json!(3_u64));
         parameters.insert("width".to_string(), json!(128_u64));
         parameters.insert("heapsize".to_string(), json!(32_u64));
+        parameters.insert("count_events".to_string(), json!(true));
         let cms = AggregationConfig::new(
             1,
             AggregationType::CountMinSketchWithHeap,


### PR DESCRIPTION
## Summary
- Require `CountMinSketchWithHeap` configs and PromQL top-k requirements to state `count_events` weighting explicitly, instead of silently defaulting/ignoring it, so mismatches fail loudly instead of matching the wrong sketch.
- Recognize `topk(k, sum_over_time(...))` and `topk(k, count_over_time(...))` (with or without `by`/`without`) in both the planner's and query-engine's pattern matchers, deriving the correct `count_events` weighting (value-weighted for `sum_over_time`/raw vector, count-weighted for `count_over_time`) from the wrapped function.

Fixes #699 — all 24 topk-over-temporal cases in the `aggregations` differential suite were failing with `destination=none_unsupported` because the planner omitted them from `inference_config.yaml` and the query engine couldn't match them at execution time. `topk(k, rate(...))`/`avg_over_time(...)`/etc. remain out of scope (not in the issue or the compliance suite).

## Test plan
- [x] `cargo test --workspace` — all passing, no regressions
- [x] `cargo fmt --check` / `cargo clippy --all-targets` — clean
- [x] New planner integration tests (`asap-planner-rs/tests/integration.rs`) pin the emitted `CountMinSketchWithHeap` config for both `topk(k, sum_over_time(...))` and `topk by (job) (k, count_over_time(...))`
- [x] New query-engine tests (`simple_engine::promql::topk_pipeline_tests`) prove `find_matching_controller_pattern`/`build_query_requirements_promql` now serve the exact symptom reported in #699
- [ ] Differential suite run against the 24 `topk-*-over-time` cases in `promql-compliance/suites/aggregations.yaml` (not run in this session — worth doing before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD4LRkJNNDb1TQ17XeQjmy