### PR TITLE
fix(query-engine): fail loudly on accumulator serialization errors

### DIFF
--- a/asap-common/dependencies/rs/asap_types/src/aggregation_config.rs
+++ b/asap-common/dependencies/rs/asap_types/src/aggregation_config.rs
@@ -346,7 +346,7 @@ impl AggregationConfig {
 }
 
 impl SerializableToSink for AggregationConfig {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, crate::traits::SerializationError> {
         let mut json = serde_json::json!({
             "aggregationId": self.aggregation_id,
             "aggregationType": self.aggregation_type,
@@ -378,10 +378,10 @@ impl SerializableToSink for AggregationConfig {
             json["valueColumn"] = serde_json::json!(value_column);
         }
 
-        json
+        Ok(json)
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.original_yaml.as_bytes().to_vec()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, crate::traits::SerializationError> {
+        Ok(self.original_yaml.as_bytes().to_vec())
     }
 }

--- a/asap-common/dependencies/rs/asap_types/src/traits.rs
+++ b/asap-common/dependencies/rs/asap_types/src/traits.rs
@@ -1,7 +1,47 @@
 use serde_json::Value;
+use std::error::Error as StdError;
+use std::fmt;
+
+/// A serialization boundary failed. Carries the failing type's name so the
+/// caller can report which accumulator/value produced empty or missing
+/// output instead of silently persisting nothing.
+#[derive(Debug)]
+pub enum SerializationError {
+    Bytes {
+        type_name: &'static str,
+        source: Box<dyn StdError + Send + Sync>,
+    },
+    Json {
+        type_name: &'static str,
+        source: Box<dyn StdError + Send + Sync>,
+    },
+}
+
+impl fmt::Display for SerializationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SerializationError::Bytes { type_name, source } => {
+                write!(f, "failed to serialize {type_name} to bytes: {source}")
+            }
+            SerializationError::Json { type_name, source } => {
+                write!(f, "failed to serialize {type_name} to JSON: {source}")
+            }
+        }
+    }
+}
+
+impl StdError for SerializationError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            SerializationError::Bytes { source, .. } | SerializationError::Json { source, .. } => {
+                Some(source.as_ref())
+            }
+        }
+    }
+}
 
 /// Trait for objects that can be serialized to different formats
 pub trait SerializableToSink {
-    fn serialize_to_json(&self) -> Value;
-    fn serialize_to_bytes(&self) -> Vec<u8>;
+    fn serialize_to_json(&self) -> Result<Value, SerializationError>;
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError>;
 }

--- a/asap-query-engine/src/data_model/key_by_label_values.rs
+++ b/asap-query-engine/src/data_model/key_by_label_values.rs
@@ -1,3 +1,4 @@
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 // use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -25,8 +26,11 @@ impl KeyByLabelValues {
         self.labels.get(index)
     }
 
-    pub fn serialize_to_json(&self) -> serde_json::Value {
-        serde_json::to_value(&self.labels).unwrap_or(serde_json::Value::Null)
+    pub fn serialize_to_json(&self) -> Result<serde_json::Value, SerializationError> {
+        serde_json::to_value(&self.labels).map_err(|e| SerializationError::Json {
+            type_name: "KeyByLabelValues",
+            source: e.into(),
+        })
     }
 
     pub fn deserialize_from_json(data: &serde_json::Value) -> Result<Self, serde_json::Error> {
@@ -34,8 +38,11 @@ impl KeyByLabelValues {
         Ok(Self { labels })
     }
 
-    pub fn serialize_to_bytes(&self) -> Vec<u8> {
-        bincode::serialize(&self.labels).unwrap_or_default()
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        bincode::serialize(&self.labels).map_err(|e| SerializationError::Bytes {
+            type_name: "KeyByLabelValues",
+            source: e.into(),
+        })
     }
 
     pub fn deserialize_from_bytes(buffer: &[u8]) -> Result<Self, Box<dyn std::error::Error>> {
@@ -118,7 +125,7 @@ mod tests {
         let mut key = KeyByLabelValues::new();
         key.insert("test".to_string());
 
-        let json = key.serialize_to_json();
+        let json = key.serialize_to_json().unwrap();
         let deserialized = KeyByLabelValues::deserialize_from_json(&json).unwrap();
         assert_eq!(key, deserialized);
     }
@@ -128,7 +135,7 @@ mod tests {
         let mut key = KeyByLabelValues::new();
         key.insert("test".to_string());
 
-        let bytes = key.serialize_to_bytes();
+        let bytes = key.serialize_to_bytes().unwrap();
         let deserialized = KeyByLabelValues::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(key, deserialized);
     }

--- a/asap-query-engine/src/data_model/measurement.rs
+++ b/asap-query-engine/src/data_model/measurement.rs
@@ -1,3 +1,4 @@
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
 
@@ -11,14 +12,14 @@ impl Measurement {
         Self { value }
     }
 
-    pub fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.value.to_le_bytes().to_vec()
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        Ok(self.value.to_le_bytes().to_vec())
     }
 
-    pub fn serialize_to_json(&self) -> serde_json::Value {
-        serde_json::json!({
+    pub fn serialize_to_json(&self) -> Result<serde_json::Value, SerializationError> {
+        Ok(serde_json::json!({
             "value": self.value
-        })
+        }))
     }
 
     pub fn deserialize_from_json(data: &serde_json::Value) -> Result<Self, serde_json::Error> {
@@ -79,7 +80,7 @@ mod tests {
     #[test]
     fn test_serialization() {
         let measurement = Measurement::new(42.5);
-        let json = measurement.serialize_to_json();
+        let json = measurement.serialize_to_json().unwrap();
         let deserialized = Measurement::deserialize_from_json(&json).unwrap();
         assert_eq!(measurement, deserialized);
     }
@@ -87,7 +88,7 @@ mod tests {
     #[test]
     fn test_byte_serialization() {
         let measurement = Measurement::new(42.5);
-        let bytes = measurement.serialize_to_bytes();
+        let bytes = measurement.serialize_to_bytes().unwrap();
         let deserialized = Measurement::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(measurement, deserialized);
     }

--- a/asap-query-engine/src/data_model/precomputed_output.rs
+++ b/asap-query-engine/src/data_model/precomputed_output.rs
@@ -6,6 +6,7 @@ use tracing::error;
 
 use crate::data_model::traits::SerializableToSink;
 use crate::data_model::{AggregationType, KeyByLabelValues, StreamingConfig};
+use asap_types::traits::SerializationError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrecomputedOutput {
@@ -442,19 +443,27 @@ impl PrecomputedOutput {
 }
 
 impl SerializableToSink for PrecomputedOutput {
-    fn serialize_to_json(&self) -> serde_json::Value {
+    fn serialize_to_json(&self) -> Result<serde_json::Value, SerializationError> {
         // Default implementation without precompute data for backward compatibility
-        serde_json::json!({
+        let key_json = self
+            .key
+            .as_ref()
+            .map(|k| k.serialize_to_json())
+            .transpose()?;
+        Ok(serde_json::json!({
             // "config": self.config.serialize_to_json(),
             "start_timestamp": self.start_timestamp,
             "end_timestamp": self.end_timestamp,
-            "key": self.key.as_ref().map(|k| k.serialize_to_json())
-        })
+            "key": key_json
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         // Default implementation without precompute data for backward compatibility
-        serde_json::to_vec(self).unwrap_or_else(|_| Vec::new())
+        serde_json::to_vec(self).map_err(|e| SerializationError::Bytes {
+            type_name: "PrecomputedOutput",
+            source: e.into(),
+        })
     }
 }
 

--- a/asap-query-engine/src/drivers/ingest/kafka.rs
+++ b/asap-query-engine/src/drivers/ingest/kafka.rs
@@ -202,11 +202,14 @@ impl<T: Store + Send + Sync + 'static> KafkaConsumer<T> {
                 );
                 debug!("{}", batch[0].0.get_freshness_debug_string());
                 for (item, _) in batch.iter() {
+                    let json_str = item
+                        .serialize_to_json()
+                        .map_err(|e| e.to_string())
+                        .and_then(|v| serde_json::to_string(&v).map_err(|e| e.to_string()))
+                        .unwrap_or_else(|e| format!("failed to serialize: {e}"));
                     debug!(
                         "Received message: {} with aggregation_id: {}",
-                        serde_json::to_string(&item.serialize_to_json())
-                            .unwrap_or_else(|_| "failed to serialize".to_string()),
-                        item.aggregation_id
+                        json_str, item.aggregation_id
                     );
                 }
             }

--- a/asap-query-engine/src/engines/simple_engine/mod.rs
+++ b/asap-query-engine/src/engines/simple_engine/mod.rs
@@ -2461,6 +2461,7 @@ mod topk_metadata_tests {
 mod range_query_tests {
     use crate::data_model::{AggregateCore, AggregationType, KeyByLabelValues, SerializableToSink};
     use crate::engines::window_merger::NaiveMerger;
+    use asap_types::traits::SerializationError;
     use serde_json::Value;
     use std::any::Any;
 
@@ -2478,12 +2479,12 @@ mod range_query_tests {
     }
 
     impl SerializableToSink for MockBucketAccumulator {
-        fn serialize_to_json(&self) -> Value {
-            serde_json::json!({"bucket_id": self.bucket_id, "value": self.value})
+        fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+            Ok(serde_json::json!({"bucket_id": self.bucket_id, "value": self.value}))
         }
 
-        fn serialize_to_bytes(&self) -> Vec<u8> {
-            format!("{}:{}", self.bucket_id, self.value).into_bytes()
+        fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+            Ok(format!("{}:{}", self.bucket_id, self.value).into_bytes())
         }
     }
 
@@ -3255,6 +3256,7 @@ mod merge_accumulators_regression_tests_596 {
     use crate::tests::test_utilities::{
         cms_from_matrix, oracle_sequential_fold, PoisonableAccumulator,
     };
+    use asap_types::traits::SerializationError;
     use serde_json::Value;
     use std::any::Any;
     use std::collections::HashMap;
@@ -3479,11 +3481,11 @@ mod merge_accumulators_regression_tests_596 {
     }
 
     impl SerializableToSink for MockOrderedLogAccumulator {
-        fn serialize_to_json(&self) -> Value {
-            serde_json::json!({"log": self.log, "last": self.last})
+        fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+            Ok(serde_json::json!({"log": self.log, "last": self.last}))
         }
-        fn serialize_to_bytes(&self) -> Vec<u8> {
-            Vec::new()
+        fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+            Ok(Vec::new())
         }
     }
 

--- a/asap-query-engine/src/engines/window_merger.rs
+++ b/asap-query-engine/src/engines/window_merger.rs
@@ -109,6 +109,7 @@ mod tests {
     use crate::tests::test_utilities::{
         cms_from_matrix, oracle_sequential_fold, PoisonableAccumulator,
     };
+    use asap_types::traits::SerializationError;
     use serde_json::Value;
     use std::any::Any;
 
@@ -125,12 +126,12 @@ mod tests {
     }
 
     impl SerializableToSink for MockSumAccumulator {
-        fn serialize_to_json(&self) -> Value {
-            serde_json::json!({"value": self.value})
+        fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+            Ok(serde_json::json!({"value": self.value}))
         }
 
-        fn serialize_to_bytes(&self) -> Vec<u8> {
-            self.value.to_le_bytes().to_vec()
+        fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+            Ok(self.value.to_le_bytes().to_vec())
         }
     }
 

--- a/asap-query-engine/src/precompute_operators/count_min_sketch_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/count_min_sketch_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     MultipleSubpopulationAggregate, SerializableToSink,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, CountMinSketch};
+use asap_types::traits::SerializationError;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -157,16 +158,21 @@ impl CountMinSketchAccumulator {
 }
 
 impl SerializableToSink for CountMinSketchAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        serde_json::json!({
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        Ok(serde_json::json!({
             "row_num": self.inner.rows(),
             "col_num": self.inner.cols(),
             "sketch": self.inner.sketch()
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.inner.to_msgpack().unwrap_or_default()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        self.inner
+            .to_msgpack()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "CountMinSketchAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 
@@ -342,7 +348,7 @@ mod tests {
             ),
         };
 
-        let bytes = cms.serialize_to_bytes();
+        let bytes = cms.serialize_to_bytes().unwrap();
         let deserialized =
             CountMinSketchAccumulator::deserialize_from_bytes_arroyo(&bytes).unwrap();
 

--- a/asap-query-engine/src/precompute_operators/count_min_sketch_with_heap_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/count_min_sketch_with_heap_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     MultipleSubpopulationAggregate, SerializableToSink,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, CmsHeapItem, CountMinSketchWithHeap};
+use asap_types::traits::SerializationError;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -108,7 +109,7 @@ impl CountMinSketchWithHeapAccumulator {
 }
 
 impl SerializableToSink for CountMinSketchWithHeapAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let heap_items: Vec<Value> = self
             .inner
             .topk_heap_items()
@@ -121,17 +122,22 @@ impl SerializableToSink for CountMinSketchWithHeapAccumulator {
             })
             .collect();
 
-        serde_json::json!({
+        Ok(serde_json::json!({
             "row_num": self.inner.rows(),
             "col_num": self.inner.cols(),
             "heap_size": self.inner.heap_size,
             "sketch": self.inner.sketch_matrix(),
             "topk_heap": heap_items
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.inner.to_msgpack().unwrap_or_default()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        self.inner
+            .to_msgpack()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "CountMinSketchWithHeapAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 
@@ -325,7 +331,7 @@ mod tests {
             inner: CountMinSketchWithHeap::from_legacy_matrix(sketch, topk_heap, 2, 3, 5),
         };
 
-        let bytes = cms.serialize_to_bytes();
+        let bytes = cms.serialize_to_bytes().unwrap();
         let deserialized =
             CountMinSketchWithHeapAccumulator::deserialize_from_bytes_arroyo(&bytes).unwrap();
 

--- a/asap-query-engine/src/precompute_operators/datasketches_kll_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/datasketches_kll_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     SingleSubpopulationAggregate,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, KllSketch};
+use asap_types::traits::SerializationError;
 use base64::{engine::general_purpose, Engine as _};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -105,15 +106,20 @@ unsafe impl Send for DatasketchesKLLAccumulator {}
 unsafe impl Sync for DatasketchesKLLAccumulator {}
 
 impl SerializableToSink for DatasketchesKLLAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         // Mirror Python implementation: {"sketch": base64_encoded_string}
         let sketch_bytes = self.inner.sketch_bytes();
         let sketch_b64 = general_purpose::STANDARD.encode(&sketch_bytes);
-        serde_json::json!({ "sketch": sketch_b64 })
+        Ok(serde_json::json!({ "sketch": sketch_b64 }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.inner.to_msgpack().unwrap_or_default()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        self.inner
+            .to_msgpack()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "DatasketchesKLLAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 
@@ -318,7 +324,7 @@ mod tests {
             kll.update(i as f64);
         }
 
-        let bytes = kll.serialize_to_bytes();
+        let bytes = kll.serialize_to_bytes().unwrap();
         let deserialized =
             DatasketchesKLLAccumulator::deserialize_from_bytes_arroyo(&bytes).unwrap();
 

--- a/asap-query-engine/src/precompute_operators/delta_set_aggregator_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/delta_set_aggregator_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     MultipleSubpopulationAggregate, SerializableToSink,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, DeltaResult};
+use asap_types::traits::SerializationError;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use tracing::warn;
@@ -178,21 +179,21 @@ impl Default for DeltaSetAggregatorAccumulator {
 }
 
 impl SerializableToSink for DeltaSetAggregatorAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let added_json: Vec<Value> = self
             .added
             .iter()
             .map(|key| key.serialize_to_json())
-            .collect();
+            .collect::<Result<_, _>>()?;
         let removed_json: Vec<Value> = self
             .removed
             .iter()
             .map(|key| key.serialize_to_json())
-            .collect();
-        serde_json::json!({ "added": added_json, "removed": removed_json })
+            .collect::<Result<_, _>>()?;
+        Ok(serde_json::json!({ "added": added_json, "removed": removed_json }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         // Delegate to sketch-core canonical DeltaResult msgpack format
         let added: HashSet<String> = self
             .added
@@ -206,7 +207,10 @@ impl SerializableToSink for DeltaSetAggregatorAccumulator {
             .collect();
         DeltaResult { added, removed }
             .to_msgpack()
-            .unwrap_or_default()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "DeltaSetAggregatorAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 
@@ -473,7 +477,7 @@ mod tests {
         acc.remove_key(key2.clone());
 
         // Test binary (msgpack) serialization roundtrip
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes =
             DeltaSetAggregatorAccumulator::deserialize_from_bytes_arroyo(&bytes).unwrap();
 

--- a/asap-query-engine/src/precompute_operators/hll_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/hll_accumulator.rs
@@ -10,6 +10,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, MergeableAccumulator, SerializableToSink,
     SingleSubpopulationAggregate,
 };
+use asap_types::traits::SerializationError;
 
 /// Default HLL precision when streaming config omits `parameters.precision`.
 pub const DEFAULT_HLL_PRECISION: u32 = 14;
@@ -61,18 +62,23 @@ impl Default for HllAccumulator {
 }
 
 impl SerializableToSink for HllAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        let bytes = self.inner.to_msgpack().unwrap_or_default();
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        let bytes = self.serialize_to_bytes()?;
         let b64 = general_purpose::STANDARD.encode(&bytes);
-        serde_json::json!({
+        Ok(serde_json::json!({
             "sketch": b64,
             "precision": self.inner.precision,
             "variant": format!("{:?}", self.inner.variant),
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.inner.to_msgpack().unwrap_or_default()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        self.inner
+            .to_msgpack()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "HllAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 
@@ -322,14 +328,14 @@ mod tests {
         // to_bytes/from_bytes drop the register state and only persist the count,
         // which would corrupt any merge that happens after a store round-trip.
         let original = build_with_n_unique(2000, 14);
-        let bytes = original.serialize_to_bytes();
+        let bytes = original.serialize_to_bytes().unwrap();
         assert!(!bytes.is_empty(), "serialize_to_bytes must produce data");
         let restored =
             HllAccumulator::deserialize_from_bytes_arroyo(&bytes).expect("msgpack round trip");
         assert_eq!(restored.precision(), original.precision());
         assert_eq!(restored.estimate(), original.estimate());
         // Bytes must be stable across re-encode (canonical form).
-        assert_eq!(restored.serialize_to_bytes(), bytes);
+        assert_eq!(restored.serialize_to_bytes().unwrap(), bytes);
     }
 
     #[test]
@@ -338,7 +344,7 @@ mod tests {
         // then merge new data — if the restored sketch had dropped its register
         // state, the post-merge estimate would underflow.
         let acc_a = build_with_n_unique(1000, 14);
-        let bytes = acc_a.serialize_to_bytes();
+        let bytes = acc_a.serialize_to_bytes().unwrap();
         let restored =
             HllAccumulator::deserialize_from_bytes_arroyo(&bytes).expect("msgpack round trip");
 
@@ -364,7 +370,7 @@ mod tests {
     #[test]
     fn json_serialisation_includes_sketch_blob_and_precision() {
         let acc = build_with_n_unique(100, 14);
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         assert!(json.get("sketch").and_then(|v| v.as_str()).is_some());
         assert_eq!(json["precision"], 14);
     }

--- a/asap-query-engine/src/precompute_operators/hydra_kll_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/hydra_kll_accumulator.rs
@@ -6,6 +6,7 @@ use crate::{
     KeyByLabelValues,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, HydraKllSketch};
+use asap_types::traits::SerializationError;
 use base64::{engine::general_purpose, Engine as _};
 use std::collections::HashMap;
 
@@ -49,15 +50,20 @@ impl HydraKllSketchAccumulator {
 }
 
 impl SerializableToSink for HydraKllSketchAccumulator {
-    fn serialize_to_json(&self) -> serde_json::Value {
+    fn serialize_to_json(&self) -> Result<serde_json::Value, SerializationError> {
         // Mirror Python implementation: {"sketch": base64_encoded_string}
-        let sketch_bytes = self.inner.to_msgpack().unwrap_or_default();
+        let sketch_bytes = self.serialize_to_bytes()?;
         let sketch_b64 = general_purpose::STANDARD.encode(&sketch_bytes);
-        serde_json::json!({ "sketch": sketch_b64 })
+        Ok(serde_json::json!({ "sketch": sketch_b64 }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.inner.to_msgpack().unwrap_or_default()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        self.inner
+            .to_msgpack()
+            .map_err(|e| SerializationError::Bytes {
+                type_name: "HydraKllSketchAccumulator",
+                source: e.to_string().into(),
+            })
     }
 }
 

--- a/asap-query-engine/src/precompute_operators/increase_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/increase_accumulator.rs
@@ -2,6 +2,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, Measurement, MergeableAccumulator, QueryBounds,
     SerializableToSink, SingleSubpopulationAggregate, SingleSubpopulationAggregateFactory,
 };
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -385,21 +386,21 @@ impl IncreaseAccumulator {
 }
 
 impl SerializableToSink for IncreaseAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        serde_json::json!({
-            "starting_measurement": self.starting_measurement.serialize_to_json(),
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        Ok(serde_json::json!({
+            "starting_measurement": self.starting_measurement.serialize_to_json()?,
             "starting_timestamp": self.starting_timestamp,
-            "last_seen_measurement": self.last_seen_measurement.serialize_to_json(),
+            "last_seen_measurement": self.last_seen_measurement.serialize_to_json()?,
             "last_seen_timestamp": self.last_seen_timestamp,
             "sample_count": self.sample_count,
             "counter_reset_adjustment": self.counter_reset_adjustment,
             "counter_reset_events": self.counter_reset_events,
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        let starting_measurement_bytes = self.starting_measurement.serialize_to_bytes();
-        let last_seen_measurement_bytes = self.last_seen_measurement.serialize_to_bytes();
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        let starting_measurement_bytes = self.starting_measurement.serialize_to_bytes()?;
+        let last_seen_measurement_bytes = self.last_seen_measurement.serialize_to_bytes()?;
 
         let mut buffer = Vec::new();
         buffer.extend_from_slice(&INCREASE_BINARY_FORMAT_MAGIC);
@@ -425,7 +426,7 @@ impl SerializableToSink for IncreaseAccumulator {
             buffer.extend_from_slice(&event.adjustment.to_le_bytes());
         }
 
-        buffer
+        Ok(buffer)
     }
 }
 
@@ -947,7 +948,7 @@ mod tests {
         acc.update(Measurement::new(25.0), 2000);
 
         // Test JSON serialization
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         assert_eq!(json["sample_count"], 3);
         assert!(json.get("opaque_reset_adjustment").is_none());
         assert!(json.get("opaque_reset_ranges").is_none());
@@ -965,7 +966,7 @@ mod tests {
         assert_eq!(acc.sample_count, deserialized.sample_count);
 
         // Test byte serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         assert_eq!(&bytes[..4], b"INC7");
         let deserialized_bytes = IncreaseAccumulator::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(
@@ -1012,8 +1013,8 @@ mod tests {
             IncreaseAccumulator::new(Measurement::new(10.0), 1000, Measurement::new(25.0), 2000);
         let second =
             IncreaseAccumulator::new(Measurement::new(30.0), 3000, Measurement::new(45.0), 4000);
-        let first_bytes = first.serialize_to_bytes();
-        let second_bytes = second.serialize_to_bytes();
+        let first_bytes = first.serialize_to_bytes().unwrap();
+        let second_bytes = second.serialize_to_bytes().unwrap();
         let mut combined = first_bytes.clone();
         combined.extend_from_slice(&second_bytes);
 
@@ -1040,14 +1041,15 @@ mod tests {
         acc.update(Measurement::new(60.0), 3_000);
 
         let json_round_trip =
-            IncreaseAccumulator::deserialize_from_json(&acc.serialize_to_json()).unwrap();
+            IncreaseAccumulator::deserialize_from_json(&acc.serialize_to_json().unwrap()).unwrap();
         assert_eq!(
             json_round_trip.query(Statistic::Increase, None).unwrap(),
             110.0
         );
 
         let bytes_round_trip =
-            IncreaseAccumulator::deserialize_from_bytes(&acc.serialize_to_bytes()).unwrap();
+            IncreaseAccumulator::deserialize_from_bytes(&acc.serialize_to_bytes().unwrap())
+                .unwrap();
         assert_eq!(
             bytes_round_trip.query(Statistic::Increase, None).unwrap(),
             110.0

--- a/asap-query-engine/src/precompute_operators/min_max_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/min_max_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, MergeableAccumulator, SerializableToSink,
     SingleSubpopulationAggregate, SingleSubpopulationAggregateFactory,
 };
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -97,14 +98,14 @@ impl MinMaxAccumulator {
 }
 
 impl SerializableToSink for MinMaxAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        serde_json::json!({
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        Ok(serde_json::json!({
             "value": self.value,
             "sub_type": self.sub_type
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         let mut bytes = self.value.to_le_bytes().to_vec();
         let sub_type_byte = match self.sub_type.as_str() {
             "min" => 0u8,
@@ -112,7 +113,7 @@ impl SerializableToSink for MinMaxAccumulator {
             _ => unreachable!("MinMaxAccumulator sub_type is always 'min' or 'max'"),
         };
         bytes.push(sub_type_byte);
-        bytes
+        Ok(bytes)
     }
 }
 
@@ -381,13 +382,13 @@ mod tests {
         let acc = MinMaxAccumulator::with_value(42.5, "min".to_string()).unwrap();
 
         // Test JSON serialization
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         let deserialized = MinMaxAccumulator::deserialize_from_json(&json).unwrap();
         assert_eq!(acc.value, deserialized.value);
         assert_eq!(acc.sub_type, deserialized.sub_type);
 
         // Test byte serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes = MinMaxAccumulator::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(acc.value, deserialized_bytes.value);
         assert_eq!(acc.sub_type, deserialized_bytes.sub_type);

--- a/asap-query-engine/src/precompute_operators/multiple_increase_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/multiple_increase_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     MultipleSubpopulationAggregate, QueryBounds, SerializableToSink, SingleSubpopulationAggregate,
 };
 use crate::precompute_operators::{CounterResetEvent, IncreaseAccumulator};
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -200,24 +201,24 @@ impl Default for MultipleIncreaseAccumulator {
 }
 
 impl SerializableToSink for MultipleIncreaseAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let entries: Vec<Value> = self
             .increases
             .iter()
             .map(|(key, data)| {
-                serde_json::json!({
-                    "key": key.serialize_to_json(),
-                    "increase_data": data.serialize_to_json()
-                })
+                Ok(serde_json::json!({
+                    "key": key.serialize_to_json()?,
+                    "increase_data": data.serialize_to_json()?
+                }))
             })
-            .collect();
+            .collect::<Result<_, SerializationError>>()?;
 
-        serde_json::json!({
+        Ok(serde_json::json!({
             "entries": entries
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         let mut buffer = Vec::new();
 
         // Write number of entries
@@ -225,15 +226,15 @@ impl SerializableToSink for MultipleIncreaseAccumulator {
 
         // Write each key-value pair
         for (key, data) in &self.increases {
-            let key_bytes = key.serialize_to_bytes();
+            let key_bytes = key.serialize_to_bytes()?;
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
             buffer.extend_from_slice(&key_bytes);
 
-            let data_bytes = data.serialize_to_bytes();
+            let data_bytes = data.serialize_to_bytes()?;
             buffer.extend_from_slice(&data_bytes);
         }
 
-        buffer
+        Ok(buffer)
     }
 }
 
@@ -498,7 +499,7 @@ mod tests {
         );
 
         // Test JSON serialization
-        let json_value = acc.serialize_to_json();
+        let json_value = acc.serialize_to_json().unwrap();
         let deserialized = MultipleIncreaseAccumulator::deserialize_from_json(&json_value).unwrap();
 
         assert_eq!(deserialized.increases.len(), 1);
@@ -508,7 +509,7 @@ mod tests {
         assert_eq!(deserialized_acc.sample_count, 2);
 
         // Test binary serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes =
             MultipleIncreaseAccumulator::deserialize_from_bytes(&bytes).unwrap();
 
@@ -585,7 +586,8 @@ mod tests {
         acc.update(key.clone(), increase_acc);
 
         let json_round_trip =
-            MultipleIncreaseAccumulator::deserialize_from_json(&acc.serialize_to_json()).unwrap();
+            MultipleIncreaseAccumulator::deserialize_from_json(&acc.serialize_to_json().unwrap())
+                .unwrap();
         assert_eq!(
             json_round_trip
                 .query(Statistic::Increase, &key, None)
@@ -594,7 +596,8 @@ mod tests {
         );
 
         let bytes_round_trip =
-            MultipleIncreaseAccumulator::deserialize_from_bytes(&acc.serialize_to_bytes()).unwrap();
+            MultipleIncreaseAccumulator::deserialize_from_bytes(&acc.serialize_to_bytes().unwrap())
+                .unwrap();
         assert_eq!(
             bytes_round_trip
                 .query(Statistic::Increase, &key, None)

--- a/asap-query-engine/src/precompute_operators/multiple_min_max_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/multiple_min_max_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, KeyByLabelValues, MergeableAccumulator,
     MultipleSubpopulationAggregate, SerializableToSink,
 };
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -169,10 +170,10 @@ impl MultipleMinMaxAccumulator {
 }
 
 impl SerializableToSink for MultipleMinMaxAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let mut values_obj = serde_json::Map::new();
         for (key, value) in &self.values {
-            let key_json = key.serialize_to_json();
+            let key_json = key.serialize_to_json()?;
             let key_str = serde_json::to_string(&key_json).unwrap();
             values_obj.insert(
                 key_str,
@@ -180,13 +181,13 @@ impl SerializableToSink for MultipleMinMaxAccumulator {
             );
         }
 
-        serde_json::json!({
+        Ok(serde_json::json!({
             "values": values_obj,
             "sub_type": self.sub_type
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         let mut buffer = Vec::new();
 
         // Write number of entries
@@ -194,7 +195,7 @@ impl SerializableToSink for MultipleMinMaxAccumulator {
 
         // Write each key-value pair
         for (key, value) in &self.values {
-            let key_bytes = key.serialize_to_bytes();
+            let key_bytes = key.serialize_to_bytes()?;
 
             // Write key length and data
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
@@ -204,7 +205,7 @@ impl SerializableToSink for MultipleMinMaxAccumulator {
             buffer.extend_from_slice(&value.to_le_bytes());
         }
 
-        buffer
+        Ok(buffer)
     }
 }
 
@@ -469,13 +470,13 @@ mod tests {
         acc.add_value(key.clone(), 42.5);
 
         // Test JSON serialization
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         let deserialized = MultipleMinMaxAccumulator::deserialize_from_json(&json).unwrap();
         assert_eq!(deserialized.values.get(&key), Some(&42.5));
         assert_eq!(deserialized.sub_type, "min");
 
         // Test byte serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes =
             MultipleMinMaxAccumulator::deserialize_from_bytes(&bytes, "min".to_string()).unwrap();
         assert_eq!(deserialized_bytes.values.get(&key), Some(&42.5));

--- a/asap-query-engine/src/precompute_operators/multiple_sum_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/multiple_sum_accumulator.rs
@@ -2,6 +2,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, KeyByLabelValues, MergeableAccumulator,
     MultipleSubpopulationAggregate, MultipleSubpopulationAggregateFactory, SerializableToSink,
 };
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -150,10 +151,10 @@ impl Default for MultipleSumAccumulator {
 }
 
 impl SerializableToSink for MultipleSumAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let mut sums_obj = serde_json::Map::new();
         for (key, sum) in &self.sums {
-            let key_json = key.serialize_to_json();
+            let key_json = key.serialize_to_json()?;
             let key_str = serde_json::to_string(&key_json).unwrap();
             sums_obj.insert(
                 key_str,
@@ -161,12 +162,12 @@ impl SerializableToSink for MultipleSumAccumulator {
             );
         }
 
-        serde_json::json!({
+        Ok(serde_json::json!({
             "sums": sums_obj
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         let mut buffer = Vec::new();
 
         // Write number of entries
@@ -174,7 +175,7 @@ impl SerializableToSink for MultipleSumAccumulator {
 
         // Write each key-value pair
         for (key, sum) in &self.sums {
-            let key_bytes = key.serialize_to_bytes();
+            let key_bytes = key.serialize_to_bytes()?;
 
             // Write key length and data
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
@@ -184,7 +185,7 @@ impl SerializableToSink for MultipleSumAccumulator {
             buffer.extend_from_slice(&sum.to_le_bytes());
         }
 
-        buffer
+        Ok(buffer)
     }
 }
 
@@ -418,12 +419,12 @@ mod tests {
         acc.add_sum(key.clone(), 42.5);
 
         // Test JSON serialization
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         let deserialized = MultipleSumAccumulator::deserialize_from_json(&json).unwrap();
         assert_eq!(deserialized.sums.get(&key), Some(&42.5));
 
         // Test byte serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes = MultipleSumAccumulator::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(deserialized_bytes.sums.get(&key), Some(&42.5));
     }

--- a/asap-query-engine/src/precompute_operators/set_aggregator_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/set_aggregator_accumulator.rs
@@ -3,6 +3,7 @@ use crate::data_model::{
     MultipleSubpopulationAggregate, SerializableToSink,
 };
 use asap_sketchlib::{message_pack_format::MessagePackCodec, SetAggregator};
+use asap_types::traits::SerializationError;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
@@ -109,7 +110,8 @@ impl SetAggregatorAccumulator {
         for key in &self.added {
             sa.update(&key.to_semicolon_str());
         }
-        sa.to_msgpack().unwrap_or_default()
+        sa.to_msgpack()
+            .expect("Failed to serialize SetAggregator to MessagePack")
     }
 }
 
@@ -120,25 +122,25 @@ impl Default for SetAggregatorAccumulator {
 }
 
 impl SerializableToSink for SetAggregatorAccumulator {
-    fn serialize_to_json(&self) -> Value {
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
         let added_json: Vec<Value> = self
             .added
             .iter()
             .map(|key| key.serialize_to_json())
-            .collect();
-        serde_json::json!({ "added": added_json })
+            .collect::<Result<_, _>>()?;
+        Ok(serde_json::json!({ "added": added_json }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         // Legacy binary format; matches deserialize_from_bytes().
         let mut buffer = Vec::new();
         buffer.extend_from_slice(&(self.added.len() as u32).to_le_bytes());
         for key in &self.added {
-            let key_bytes = key.serialize_to_bytes();
+            let key_bytes = key.serialize_to_bytes()?;
             buffer.extend_from_slice(&(key_bytes.len() as u32).to_le_bytes());
             buffer.extend_from_slice(&key_bytes);
         }
-        buffer
+        Ok(buffer)
     }
 }
 
@@ -303,14 +305,14 @@ mod tests {
         acc.add_key(key2.clone());
 
         // Test JSON serialization
-        let json_value = acc.serialize_to_json();
+        let json_value = acc.serialize_to_json().unwrap();
         let deserialized = SetAggregatorAccumulator::deserialize_from_json(&json_value).unwrap();
         assert_eq!(deserialized.added.len(), 2);
         assert!(deserialized.added.contains(&key1));
         assert!(deserialized.added.contains(&key2));
 
         // Test binary serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes = SetAggregatorAccumulator::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(deserialized_bytes.added.len(), 2);
         assert!(deserialized_bytes.added.contains(&key1));

--- a/asap-query-engine/src/precompute_operators/sum_accumulator.rs
+++ b/asap-query-engine/src/precompute_operators/sum_accumulator.rs
@@ -2,6 +2,7 @@ use crate::data_model::{
     AggregateCore, AggregationType, MergeableAccumulator, SerializableToSink,
     SingleSubpopulationAggregate, SingleSubpopulationAggregateFactory,
 };
+use asap_types::traits::SerializationError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -64,15 +65,15 @@ impl Default for SumAccumulator {
 }
 
 impl SerializableToSink for SumAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        serde_json::json!({
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        Ok(serde_json::json!({
             "sum": self.sum
-        })
+        }))
     }
 
-    fn serialize_to_bytes(&self) -> Vec<u8> {
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
         // Match Python's struct.pack("<f", self.sum) - 4-byte little-endian float
-        (self.sum as f32).to_le_bytes().to_vec()
+        Ok((self.sum as f32).to_le_bytes().to_vec())
     }
 }
 
@@ -252,12 +253,12 @@ mod tests {
         let acc = SumAccumulator::with_sum(42.5);
 
         // Test JSON serialization
-        let json = acc.serialize_to_json();
+        let json = acc.serialize_to_json().unwrap();
         let deserialized = SumAccumulator::deserialize_from_json(&json).unwrap();
         assert_eq!(acc.sum, deserialized.sum);
 
         // Test byte serialization
-        let bytes = acc.serialize_to_bytes();
+        let bytes = acc.serialize_to_bytes().unwrap();
         let deserialized_bytes = SumAccumulator::deserialize_from_bytes(&bytes).unwrap();
         assert_eq!(acc.sum, deserialized_bytes.sum);
     }

--- a/asap-query-engine/src/tests/exact_window_grid_adversarial_tests.rs
+++ b/asap-query-engine/src/tests/exact_window_grid_adversarial_tests.rs
@@ -326,13 +326,23 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing bucket {range:?}"))
                 .1
                 .serialize_to_json()
+                .unwrap()
         };
         let j1 = json_for((0, 3_000));
         let j2 = json_for((1_000, 4_000));
         let j3 = json_for((2_000, 5_000));
-        assert_eq!(j1, SumAccumulator::with_sum(1.0).serialize_to_json());
-        assert_eq!(j2, SumAccumulator::with_sum(2.0).serialize_to_json());
-        assert_eq!(j3, SumAccumulator::with_sum(3.0).serialize_to_json());
+        assert_eq!(
+            j1,
+            SumAccumulator::with_sum(1.0).serialize_to_json().unwrap()
+        );
+        assert_eq!(
+            j2,
+            SumAccumulator::with_sum(2.0).serialize_to_json().unwrap()
+        );
+        assert_eq!(
+            j3,
+            SumAccumulator::with_sum(3.0).serialize_to_json().unwrap()
+        );
     }
 
     /// Range query spanning both sealed epochs and the still-open (mutable)
@@ -383,9 +393,11 @@ mod tests {
         for i in 2..n {
             let range = (i * 60_000, (i + 1) * 60_000);
             let acc = &buckets.iter().find(|(r, _)| *r == range).unwrap().1;
-            let expected_json = SumAccumulator::with_sum(i as f64).serialize_to_json();
+            let expected_json = SumAccumulator::with_sum(i as f64)
+                .serialize_to_json()
+                .unwrap();
             assert_eq!(
-                acc.serialize_to_json(),
+                acc.serialize_to_json().unwrap(),
                 expected_json,
                 "window {i} must return its own value across the sealed/mutable epoch boundary"
             );

--- a/asap-query-engine/src/tests/store_correctness_tests.rs
+++ b/asap-query-engine/src/tests/store_correctness_tests.rs
@@ -387,7 +387,7 @@ fn test_exact_query_is_stable_across_repeated_calls(strategy: LockStrategy) {
             "[{}] call #{call}: repeated exact query must keep finding the inserted window",
             label(strategy)
         );
-        jsons.push(result.get(&None).unwrap()[0].1.serialize_to_json());
+        jsons.push(result.get(&None).unwrap()[0].1.serialize_to_json().unwrap());
     }
     assert!(
         jsons.iter().all(|j| j == &jsons[0]),
@@ -493,8 +493,10 @@ fn test_exact_query_correct_across_interleaved_inserts_and_queries(strategy: Loc
                 "[{}] window {j} must be retrievable after inserting window {i}",
                 label(strategy)
             );
-            let expected = SumAccumulator::with_sum(j as f64).serialize_to_json();
-            let actual = result.get(&None).unwrap()[0].1.serialize_to_json();
+            let expected = SumAccumulator::with_sum(j as f64)
+                .serialize_to_json()
+                .unwrap();
+            let actual = result.get(&None).unwrap()[0].1.serialize_to_json().unwrap();
             assert_eq!(
                 actual,
                 expected,
@@ -543,8 +545,10 @@ fn test_exact_query_correct_after_epoch_rotation(strategy: LockStrategy) {
             "[{}] window {i} must be retrievable via exact query after epoch rotation",
             label(strategy)
         );
-        let expected = SumAccumulator::with_sum(i as f64).serialize_to_json();
-        let actual = result.get(&None).unwrap()[0].1.serialize_to_json();
+        let expected = SumAccumulator::with_sum(i as f64)
+            .serialize_to_json()
+            .unwrap();
+        let actual = result.get(&None).unwrap()[0].1.serialize_to_json().unwrap();
         assert_eq!(
             actual,
             expected,
@@ -1224,7 +1228,7 @@ fn roundtrip<A: AggregateCore + 'static>(
 ) -> (Box<dyn AggregateCore>, Box<dyn AggregateCore>) {
     let store = make_store_simple(strategy);
     let original_box: Box<dyn AggregateCore> = Box::new(original);
-    let original_json = original_box.serialize_to_json();
+    let original_json = original_box.serialize_to_json().unwrap();
 
     let (out, acc) = unkeyed_entry(1, 1_000, 2_000, original_box);
     store.insert_precomputed_output(out, acc).unwrap();
@@ -1247,7 +1251,7 @@ fn roundtrip<A: AggregateCore + 'static>(
 
     // Return a SumAccumulator that carries the original JSON as a workaround —
     // instead, compare directly here using the captured JSON.
-    let retrieved_json = retrieved.serialize_to_json();
+    let retrieved_json = retrieved.serialize_to_json().unwrap();
     assert_eq!(
         original_json,
         retrieved_json,
@@ -1313,7 +1317,7 @@ fn test_clone_fidelity_delta_set_aggregator(strategy: LockStrategy) {
     let mut acc = DeltaSetAggregatorAccumulator::new();
     acc.add_key(key(&["svc", "added-1"]));
     acc.remove_key(key(&["svc", "removed-1"]));
-    let original_json = acc.serialize_to_json();
+    let original_json = acc.serialize_to_json().unwrap();
 
     let acc_box: Box<dyn AggregateCore> = Box::new(acc);
     let (out, boxed) = unkeyed_entry(1, 1_000, 2_000, acc_box);
@@ -1325,7 +1329,7 @@ fn test_clone_fidelity_delta_set_aggregator(strategy: LockStrategy) {
     let retrieved = &result.get(&None).unwrap()[0].1;
     assert_eq!(
         original_json,
-        retrieved.serialize_to_json(),
+        retrieved.serialize_to_json().unwrap(),
         "[{}] DeltaSetAggregatorAccumulator: clone must preserve added/removed sets",
         label(strategy)
     );

--- a/asap-query-engine/src/tests/test_utilities/merge_fixtures.rs
+++ b/asap-query-engine/src/tests/test_utilities/merge_fixtures.rs
@@ -7,6 +7,7 @@
 use crate::data_model::{AggregateCore, AggregationType, KeyByLabelValues, SerializableToSink};
 use crate::precompute_operators::CountMinSketchAccumulator;
 use asap_sketchlib::CountMinSketch;
+use asap_types::traits::SerializationError;
 use serde_json::Value;
 use std::any::Any;
 
@@ -36,9 +37,9 @@ pub fn oracle_sequential_fold(buckets: &[Box<dyn AggregateCore>]) -> Box<dyn Agg
     acc
 }
 
-/// Mock accumulator whose `merge_with` fails under a condition the test
-/// fully controls (a `poisoned` flag), independent of any real
-/// accumulator's library-specific error conditions.
+/// Mock accumulator whose `merge_with` and serialization fail under a
+/// condition the test fully controls (a `poisoned` flag), independent of
+/// any real accumulator's library-specific error conditions.
 #[derive(Clone, Debug)]
 pub struct PoisonableAccumulator {
     pub id: u32,
@@ -46,11 +47,23 @@ pub struct PoisonableAccumulator {
 }
 
 impl SerializableToSink for PoisonableAccumulator {
-    fn serialize_to_json(&self) -> Value {
-        serde_json::json!({"id": self.id})
+    fn serialize_to_json(&self) -> Result<Value, SerializationError> {
+        if self.poisoned {
+            return Err(SerializationError::Json {
+                type_name: "PoisonableAccumulator",
+                source: format!("poisoned accumulator id {}", self.id).into(),
+            });
+        }
+        Ok(serde_json::json!({"id": self.id}))
     }
-    fn serialize_to_bytes(&self) -> Vec<u8> {
-        self.id.to_le_bytes().to_vec()
+    fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+        if self.poisoned {
+            return Err(SerializationError::Bytes {
+                type_name: "PoisonableAccumulator",
+                source: format!("poisoned accumulator id {}", self.id).into(),
+            });
+        }
+        Ok(self.id.to_le_bytes().to_vec())
     }
 }
 
@@ -93,5 +106,30 @@ impl AggregateCore for PoisonableAccumulator {
         _query_kwargs: &std::collections::HashMap<String, String>,
     ) -> Result<f64, Box<dyn std::error::Error + Send + Sync>> {
         Err("PoisonableAccumulator does not support query_statistic".into())
+    }
+}
+
+#[cfg(test)]
+mod poisoned_serialization_tests {
+    use super::*;
+
+    // Regression test for #673: a poisoned accumulator must return an error
+    // from the serialization boundary, not empty bytes/JSON.
+    #[test]
+    fn poisoned_accumulator_fails_serialization_loudly() {
+        let acc = PoisonableAccumulator {
+            id: 3,
+            poisoned: true,
+        };
+
+        let bytes_err = acc
+            .serialize_to_bytes()
+            .expect_err("poisoned accumulator must fail serialize_to_bytes");
+        assert!(bytes_err.to_string().contains("PoisonableAccumulator"));
+
+        let json_err = acc
+            .serialize_to_json()
+            .expect_err("poisoned accumulator must fail serialize_to_json");
+        assert!(json_err.to_string().contains("PoisonableAccumulator"));
     }
 }

--- a/asap-query-engine/src/utils/precompute_dumper.rs
+++ b/asap-query-engine/src/utils/precompute_dumper.rs
@@ -61,7 +61,13 @@ impl PrecomputeDumper {
             timestamp,
             metadata: output.clone(),
             accumulator_type: accumulator.type_name().to_string(),
-            accumulator_data_bytes: accumulator.serialize_to_bytes(),
+            accumulator_data_bytes: accumulator.serialize_to_bytes().map_err(|e| {
+                format!(
+                    "aggregation_id={}: failed to serialize {}: {e}",
+                    output.aggregation_id,
+                    accumulator.type_name()
+                )
+            })?,
         };
 
         // Serialize to MessagePack
@@ -132,6 +138,7 @@ impl Drop for PrecomputeDumper {
 mod tests {
     use super::*;
     use crate::precompute_operators::SumAccumulator;
+    use crate::tests::test_utilities::PoisonableAccumulator;
     use tempfile::TempDir;
 
     #[test]
@@ -172,5 +179,34 @@ mod tests {
         // Test flushing
         let flush_result = dumper.flush();
         assert!(flush_result.is_ok());
+    }
+
+    // Regression test for #673: a serialization failure must surface as an
+    // error carrying the aggregation id, and nothing may be written to the
+    // dump file for that record.
+    #[test]
+    fn test_dump_precompute_fails_loudly_on_serialization_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path().to_str().unwrap();
+
+        let mut dumper = PrecomputeDumper::new(output_dir).unwrap();
+
+        let accumulator = PoisonableAccumulator {
+            id: 7,
+            poisoned: true,
+        };
+        let output = PrecomputedOutput {
+            start_timestamp: 1000,
+            end_timestamp: 2000,
+            key: None,
+            aggregation_id: 42,
+        };
+
+        let err = dumper
+            .dump_precompute(&output, &accumulator)
+            .expect_err("serialization failure must propagate as an error");
+        assert!(err.to_string().contains("aggregation_id=42"));
+        assert!(err.to_string().contains("PoisonableAccumulator"));
+        assert_eq!(dumper.get_dump_count(), 0, "no record should be persisted");
     }
 }


### PR DESCRIPTION
## Summary
- `SerializableToSink::serialize_to_json`/`serialize_to_bytes` now return `Result<_, SerializationError>` instead of swallowing msgpack/serde encode failures via `.unwrap_or_default()`, which produced an empty payload indistinguishable from a legitimate empty sketch.
- Fixed the 7 accumulator impls (HLL, CMS, CMS-with-heap, DeltaSetAggregator, HydraKLL, SetAggregator's arroyo helper, DatasketchesKLL) that hit this bug, plus `KeyByLabelValues` and `PrecomputedOutput`, which had the same swallow-to-default pattern.
- `PrecomputeDumper::dump_precompute` now propagates the error with the failing accumulator's type and the record's `aggregation_id` attached, and writes nothing to the dump file when serialization fails.
- Added regression tests: a poisoned-accumulator unit test at the trait boundary, and a `PrecomputeDumper` test asserting the error message and that no record is persisted.

## Test plan
- [x] `cargo test -p query_engine_rust -p asap_types --lib` — 616 + 58 tests pass
- [x] `cargo clippy -p query_engine_rust -p asap_types --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Fixes #673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)