### PR TITLE
fix(query-engine): topk forwards wrapped function's dropped metric name (#710)

### DIFF
--- a/asap-query-engine/src/engines/simple_engine/elastic.rs
+++ b/asap-query-engine/src/engines/simple_engine/elastic.rs
@@ -136,6 +136,8 @@ impl SimpleEngine {
             query_output_labels: query_output_labels.clone(),
             statistic_to_compute,
             query_kwargs: query_kwargs.clone(),
+            // Elastic never computes Topk, so this is never read.
+            keep_metric_name: true,
         };
         Some((metric, metadata))
     }

--- a/asap-query-engine/src/engines/simple_engine/mod.rs
+++ b/asap-query-engine/src/engines/simple_engine/mod.rs
@@ -43,6 +43,12 @@ pub struct QueryMetadata {
     pub statistic_to_compute: Statistic,
     /// Additional parameters (e.g., "quantile" -> "0.95", "k" -> "10")
     pub query_kwargs: HashMap<String, String>,
+    /// Whether a Topk query's output should carry the wrapped metric's
+    /// `__name__` (Prometheus's DropName, mirrored here only for Topk: a
+    /// bare `topk(k, metric)` keeps it, but `topk(k, sum_over_time(...))`
+    /// forwards sum_over_time's dropped name -- #710). Unused outside the
+    /// PromQL Topk formatting path.
+    pub keep_metric_name: bool,
 }
 
 /// Parameters for a single store query
@@ -1102,7 +1108,7 @@ impl SimpleEngine {
             unformatted_results,
             &context.metadata.statistic_to_compute,
             &context.metric,
-            enable_topk_formatting,
+            enable_topk_formatting && context.metadata.keep_metric_name,
         );
         if enable_topk_limiting && context.metadata.statistic_to_compute == Statistic::Topk {
             results.truncate(Self::parse_topk_limit(&context.metadata.query_kwargs)?);
@@ -2426,7 +2432,10 @@ impl SimpleEngine {
         // not once per timestep -- a separate pass over the final results,
         // after every timestamp's ranking above has already decided which
         // groups/samples survive.
-        if enable_topk_formatting && context.base.metadata.statistic_to_compute == Statistic::Topk {
+        if enable_topk_formatting
+            && context.base.metadata.statistic_to_compute == Statistic::Topk
+            && context.base.metadata.keep_metric_name
+        {
             for elem in results.values_mut() {
                 Self::prepend_metric_name(&context.base.metric, &mut elem.labels);
             }

--- a/asap-query-engine/src/engines/simple_engine/promql.rs
+++ b/asap-query-engine/src/engines/simple_engine/promql.rs
@@ -351,7 +351,13 @@ impl SimpleEngine {
         }
         let statistic_to_compute = requirements.statistics[0];
 
-        if statistic_to_compute == Statistic::Topk {
+        // A wrapped temporal function (`"function"` token present, e.g.
+        // sum_over_time/count_over_time) drops __name__ in real Prometheus,
+        // and topk forwards that; a bare vector selector under topk keeps
+        // it. See #710.
+        let keep_metric_name = !match_result.tokens.contains_key("function");
+
+        if statistic_to_compute == Statistic::Topk && keep_metric_name {
             let mut new_labels = vec![METRIC_NAME_LABEL.to_string()];
             new_labels.extend(query_output_labels.labels);
             query_output_labels = KeyByLabelNames::new(new_labels);
@@ -369,6 +375,7 @@ impl SimpleEngine {
             query_output_labels: query_output_labels.clone(),
             statistic_to_compute,
             query_kwargs,
+            keep_metric_name,
         };
 
         let (query_plan, do_merge, value_window_type) = self
@@ -1722,5 +1729,221 @@ mod topk_pipeline_tests {
         for element in &results {
             assert_eq!(element.labels.labels.len(), 1);
         }
+    }
+
+    const TOPK_OVER_SUM_OVER_TIME_QUERY: &str = "topk(10, sum_over_time(transfer_events[5m]))";
+    // Must be aligned to the 5m (300_000ms) window, unlike QUERY_TIME (only
+    // 1s-aligned) -- `execute_query_pipeline`'s instant-as-range widening
+    // re-anchors the store window at the raw query time, not the aligned
+    // window `create_store_query_plan` computed, so an unaligned time here
+    // would look up a window the inserted PrecomputedOutput never covers.
+    const TOPK_OVER_SUM_OVER_TIME_QUERY_TIME: f64 = 1_759_276_800.0;
+
+    const TOPK_OVER_COUNT_OVER_TIME_QUERY: &str = "topk(10, count_over_time(transfer_events[5m]))";
+
+    /// Same engine shape as `build_topk_engine`, but the registered query
+    /// wraps a temporal aggregation (`sum_over_time`/`count_over_time`)
+    /// instead of a bare vector selector -- #710.
+    fn build_topk_over_temporal_engine(query: &str) -> (SimpleEngine, Arc<SimpleMapStore>) {
+        let promql_schema = PromQLSchema::new().add_metric(
+            METRIC.to_string(),
+            KeyByLabelNames::new(vec!["srcip".to_string()]),
+        );
+        let query_config = QueryConfig::new(query.to_string())
+            .add_aggregation(AggregationReference::new(AGG_ID, None));
+        let inference_config = InferenceConfig {
+            schema: SchemaConfig::PromQL(promql_schema),
+            query_configs: vec![query_config],
+            cleanup_policy: CleanupPolicy::NoCleanup,
+        };
+
+        let agg_config = AggregationConfig {
+            aggregation_id: AGG_ID,
+            aggregation_type: AggregationType::CountMinSketchWithHeap,
+            aggregation_sub_type: String::new(),
+            parameters: HashMap::new(),
+            grouping_labels: KeyByLabelNames::empty(),
+            aggregated_labels: KeyByLabelNames::new(vec!["srcip".to_string()]),
+            rollup_labels: KeyByLabelNames::empty(),
+            original_yaml: String::new(),
+            window_size_ms: 300_000,
+            slide_interval_ms: 300_000,
+            window_type: WindowType::Tumbling,
+            spatial_filter: String::new(),
+            spatial_filter_normalized: String::new(),
+            metric: METRIC.to_string(),
+            num_aggregates_to_retain: None,
+            read_count_threshold: None,
+            table_name: None,
+            value_column: None,
+        };
+        let mut agg_configs = HashMap::new();
+        agg_configs.insert(AGG_ID, agg_config);
+        let streaming_config = Arc::new(StreamingConfig {
+            aggregation_configs: agg_configs,
+        });
+
+        let store = Arc::new(SimpleMapStore::new(
+            streaming_config.clone(),
+            CleanupPolicy::NoCleanup,
+        ));
+        let engine = SimpleEngine::new(
+            store.clone(),
+            inference_config,
+            streaming_config,
+            1000,
+            QueryLanguage::promql,
+        );
+        (engine, store)
+    }
+
+    /// #710: `topk(k, count_over_time(...))` forwards count_over_time's
+    /// dropped metric name, same as sum_over_time -- the fix reads "is a
+    /// temporal function wrapped" generically, not a per-function allowlist.
+    #[test]
+    fn topk_over_count_over_time_output_labels_drop_metric_name() {
+        let (engine, _store) = build_topk_over_temporal_engine(TOPK_OVER_COUNT_OVER_TIME_QUERY);
+
+        let context = engine
+            .build_query_execution_context_promql(
+                TOPK_OVER_COUNT_OVER_TIME_QUERY.to_string(),
+                TOPK_OVER_SUM_OVER_TIME_QUERY_TIME,
+            )
+            .expect(
+                "topk(k, count_over_time(...)) should build a context via the query_config path",
+            );
+
+        assert_eq!(context.metadata.statistic_to_compute, Statistic::Topk);
+        assert_eq!(
+            context.metadata.query_output_labels.labels,
+            vec!["srcip".to_string()],
+            "count_over_time drops __name__, and topk forwards that -- no __name__ column here",
+        );
+    }
+
+    /// #710: `topk(k, sum_over_time(...))` forwards sum_over_time's dropped
+    /// metric name (real Prometheus DropName semantics) -- unlike bare
+    /// `topk(k, metric)`, which keeps it.
+    #[test]
+    fn topk_over_sum_over_time_output_labels_drop_metric_name() {
+        let (engine, _store) = build_topk_over_temporal_engine(TOPK_OVER_SUM_OVER_TIME_QUERY);
+
+        let context = engine
+            .build_query_execution_context_promql(
+                TOPK_OVER_SUM_OVER_TIME_QUERY.to_string(),
+                TOPK_OVER_SUM_OVER_TIME_QUERY_TIME,
+            )
+            .expect("topk(k, sum_over_time(...)) should build a context via the query_config path");
+
+        assert_eq!(
+            context.metadata.statistic_to_compute,
+            Statistic::Topk,
+            "topk(...) must resolve to Statistic::Topk",
+        );
+        assert_eq!(
+            context.metadata.query_output_labels.labels,
+            vec!["srcip".to_string()],
+            "sum_over_time drops __name__, and topk forwards that -- no __name__ column here",
+        );
+    }
+
+    /// #710: the actual result rows (not just the header) must agree with
+    /// `query_output_labels` on whether __name__ is present -- a mismatch
+    /// would silently misalign every downstream label when the wire format
+    /// zips header keys against row label values positionally
+    /// (`convert_query_result_to_prometheus`, `utils/http.rs`).
+    #[test]
+    fn topk_over_sum_over_time_rows_drop_metric_name_and_match_header_length() {
+        let (engine, store) = build_topk_over_temporal_engine(TOPK_OVER_SUM_OVER_TIME_QUERY);
+
+        let context = engine
+            .build_query_execution_context_promql(
+                TOPK_OVER_SUM_OVER_TIME_QUERY.to_string(),
+                TOPK_OVER_SUM_OVER_TIME_QUERY_TIME,
+            )
+            .expect("context should build");
+        let window = &context.store_plan.values_query;
+
+        let mut sketch = CountMinSketchWithHeapAccumulator::new(3, 1024, 32);
+        for i in 1..=15u64 {
+            let srcip = format!("10.0.0.{i}");
+            sketch.inner.update(&srcip, (i * 10) as f64);
+        }
+
+        let output =
+            PrecomputedOutput::new(window.start_timestamp, window.end_timestamp, None, AGG_ID);
+        store
+            .insert_precomputed_output(output, Box::new(sketch))
+            .expect("insert should succeed");
+
+        let results = engine
+            .execute_query_pipeline(&context, true, true)
+            .expect("pipeline should produce results");
+
+        assert_eq!(results.len(), 10, "topk(10, ...) must truncate to 10 rows");
+        for element in &results {
+            assert_eq!(
+                element.labels.labels.len(),
+                1,
+                "sum_over_time drops __name__ -- row must carry only srcip, no metric-name prefix",
+            );
+            assert!(
+                element.labels.labels[0].starts_with("10.0.0."),
+                "the one label must be the srcip value, not the metric name: {:?}",
+                element.labels.labels,
+            );
+            assert_eq!(
+                element.labels.labels.len(),
+                context.metadata.query_output_labels.labels.len(),
+                "row label count must match the output-labels header, or the wire format's \
+                 positional zip silently misaligns every subsequent label",
+            );
+        }
+    }
+
+    /// #710 side effect: a topk-over-temporal-function leaf inside a binary
+    /// arithmetic expression derives its output-label *header* from the same
+    /// `query_output_labels` this fix corrects (`resolve_arm_leaf_context` ->
+    /// `binary_matching_label_names`), even though row *values* never carry
+    /// the metric name in a binary arm regardless (formatting is disabled
+    /// there, per `topk_wrapped_in_binary_expr_truncates_without_metric_name`
+    /// above). Before this fix the header claimed a __name__ column no row
+    /// ever filled; confirm it no longer does for a wrapped temporal
+    /// function.
+    #[test]
+    fn topk_over_sum_over_time_wrapped_in_binary_expr_header_has_no_metric_name() {
+        let (engine, store) = build_topk_over_temporal_engine(TOPK_OVER_SUM_OVER_TIME_QUERY);
+
+        let context = engine
+            .build_query_execution_context_promql(
+                TOPK_OVER_SUM_OVER_TIME_QUERY.to_string(),
+                TOPK_OVER_SUM_OVER_TIME_QUERY_TIME,
+            )
+            .expect("context should build");
+        let window = &context.store_plan.values_query;
+
+        let mut sketch = CountMinSketchWithHeapAccumulator::new(3, 1024, 32);
+        for i in 1..=15u64 {
+            let srcip = format!("10.0.0.{i}");
+            sketch.inner.update(&srcip, (i * 10) as f64);
+        }
+        let output =
+            PrecomputedOutput::new(window.start_timestamp, window.end_timestamp, None, AGG_ID);
+        store
+            .insert_precomputed_output(output, Box::new(sketch))
+            .expect("insert should succeed");
+
+        let (output_labels, _) = engine
+            .handle_query_promql(
+                format!("{TOPK_OVER_SUM_OVER_TIME_QUERY} + 0"),
+                TOPK_OVER_SUM_OVER_TIME_QUERY_TIME,
+            )
+            .expect("binary-expr-wrapped topk-over-sum_over_time should still resolve");
+
+        assert_eq!(
+            output_labels.labels,
+            vec!["srcip".to_string()],
+            "sum_over_time drops __name__ -- the binary-expr header must not claim it either",
+        );
     }
 }

--- a/asap-query-engine/src/engines/simple_engine/sql.rs
+++ b/asap-query-engine/src/engines/simple_engine/sql.rs
@@ -469,6 +469,9 @@ impl SimpleEngine {
             query_output_labels: query_output_labels.clone(),
             statistic_to_compute,
             query_kwargs: query_kwargs.clone(),
+            // SQL top-k never enables Topk output formatting (rows stay as
+            // bare `(group-by columns, value)`), so this is never read.
+            keep_metric_name: true,
         };
 
         // Calculate timestamps

--- a/asap-query-engine/src/tests/test_utilities/comparison.rs
+++ b/asap-query-engine/src/tests/test_utilities/comparison.rs
@@ -187,6 +187,7 @@ mod tests {
                 query_output_labels: KeyByLabelNames::new(vec!["L1".to_string(), "L2".to_string()]),
                 statistic_to_compute: Statistic::Sum,
                 query_kwargs: HashMap::new(),
+                keep_metric_name: true,
             },
             store_plan: StoreQueryPlan {
                 values_query: StoreQueryParams {

--- a/promql-compliance/suites/aggregations.yaml
+++ b/promql-compliance/suites/aggregations.yaml
@@ -74,6 +74,25 @@ queries:
     instant_offsets_seconds: *evaluation_offsets
     range: *evaluation_range
 
+  # Bare-selector topk (no wrapped temporal function): unlike every
+  # topk-over-temporal case below, this keeps __name__ -- see #710.
+  - name: topk-1-bare
+    expr: "topk(1, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-3-bare
+    expr: "topk(3, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-5-bare
+    expr: "topk(5, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+  - name: topk-10-bare
+    expr: "topk(10, data)"
+    instant_offsets_seconds: *evaluation_offsets
+    range: *evaluation_range
+
   # Zero-label grouping is the ordinary aggregate form. One- and two-label
   # forms retain job, then job+instance, respectively.
   - name: topk-1-sum-over-time


### PR DESCRIPTION
## Summary
- `topk(...)`'s output unconditionally kept `__name__`, gated only on `Statistic::Topk`, never on whether the wrapped expression drops the name per real Prometheus semantics. `topk(k, sum_over_time(...)/count_over_time(...))` should drop it (the wrapped function's `DropName` forwards through topk); `topk(k, metric)` keeps it.
- Add `QueryMetadata.keep_metric_name`, computed once from whether the PromQL match result has a `"function"` token (topk wraps a temporal function vs. a bare vector selector), and gate both the output-labels header and the row-level metric-name prepend on it, so header and rows can't drift apart (a mismatch there would silently misalign every downstream label in the wire format's positional zip).
- Fixes as a side effect: the output-labels header for a topk-over-temporal-function wrapped in a binary expression (e.g. `topk(5, sum_over_time(x[5m])) + 0`) previously over-claimed a `__name__` column no row ever filled.
- Closes #710.

## Test plan
- [x] New unit tests (`asap-query-engine/src/engines/simple_engine/promql.rs`): header-only checks for `topk` over `sum_over_time` and `count_over_time`, a full-pipeline test asserting rows drop the name *and* match the header length, and the binary-expr header regression test.
- [x] `cargo test --lib -p query_engine_rust` — 622/622 passing, no regressions.
- [x] `cargo build --workspace` — clean.
- [x] Added the previously-missing bare-`topk(k, data)` case (k=1/3/5/10) to `promql-compliance/suites/aggregations.yaml` — this direction had zero e2e coverage before.
- [x] Re-ran the `promql-compliance` differential suite (`aggregations` dataset/suite) against real Prometheus. **The `__name__` bug itself is confirmed fixed**: no `topk`-over-`sum_over_time`/`count_over_time` case shows a stray `__name__` anymore, and the new bare `topk-N-bare` cases correctly keep it. The suite's overall pass/fail is not clean, but the remaining failures are unrelated to this change:
  - Widespread numeric value mismatches on queries this PR never touches (`sum`, `count`, `quantile`, plain `sum_over_time`/`count_over_time` with no topk) — a pre-existing environment/data-seeding issue on the machine this was run on, not a regression from this diff.
  - `topk-1-count-over-time` fails on a tie-break pick (`job="frontend"` vs `job="backend"`, both value=5) between ASAPQuery and Prometheus when multiple series tie exactly — a separate, pre-existing nondeterminism, not a `__name__`/label issue (confirmed no `__name__` appears in either side's output for this case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPdQqdcgNYxNTUvq61ypJ
