### PR TITLE
test(promql-compliance): isolate #705 sparse-cadence bug with a dense-cadence baseline

### DIFF
--- a/promql-compliance/datasets/aggregations-dense-cadence.yaml
+++ b/promql-compliance/datasets/aggregations-dense-cadence.yaml
@@ -1,0 +1,173 @@
+name: aggregations-dense-cadence
+series:
+  # Same as aggregations.yaml, but every series samples at 60s (the query
+  # step) instead of backend/i-2 and worker/i-2 sampling slower than it --
+  # that mismatch is #705's sparse-cadence bug. aggregations.yaml is left
+  # as the red case tracking it; this is the green baseline for the same
+  # query shapes.
+  #
+  # Each series also has one extra sample at offset_seconds 1260, past the
+  # suite's last evaluated offset (1200) so the trailing window has a real
+  # later sample to close on, instead of only the wall-clock idle fallback.
+  - metric: data
+    labels:
+      job: frontend
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 100}
+      - {offset_seconds: 60, value: 160}
+      - {offset_seconds: 120, value: 220}
+      - {offset_seconds: 180, value: 280}
+      - {offset_seconds: 240, value: 340}
+      - {offset_seconds: 300, value: 400}
+      - {offset_seconds: 360, value: 460}
+      - {offset_seconds: 420, value: 520}
+      - {offset_seconds: 480, value: 580}
+      - {offset_seconds: 540, value: 640}
+      - {offset_seconds: 600, value: 700}
+      - {offset_seconds: 660, value: 760}
+      - {offset_seconds: 720, value: 820}
+      - {offset_seconds: 780, value: 880}
+      - {offset_seconds: 840, value: 940}
+      - {offset_seconds: 900, value: 1000}
+      - {offset_seconds: 960, value: 1060}
+      - {offset_seconds: 1020, value: 1120}
+      - {offset_seconds: 1080, value: 1180}
+      - {offset_seconds: 1140, value: 1240}
+      - {offset_seconds: 1200, value: 1300}
+      - {offset_seconds: 1260, value: 1360}
+  - metric: data
+    labels:
+      job: frontend
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 200}
+      - {offset_seconds: 60, value: 320}
+      - {offset_seconds: 120, value: 440}
+      - {offset_seconds: 180, value: 560}
+      - {offset_seconds: 240, value: 680}
+      - {offset_seconds: 300, value: 800}
+      - {offset_seconds: 360, value: 920}
+      - {offset_seconds: 420, value: 1040}
+      - {offset_seconds: 480, value: 1160}
+      - {offset_seconds: 540, value: 1280}
+      - {offset_seconds: 600, value: 1400}
+      - {offset_seconds: 660, value: 1520}
+      - {offset_seconds: 720, value: 1640}
+      - {offset_seconds: 780, value: 1760}
+      - {offset_seconds: 840, value: 1880}
+      - {offset_seconds: 900, value: 2000}
+      - {offset_seconds: 960, value: 2120}
+      - {offset_seconds: 1020, value: 2240}
+      - {offset_seconds: 1080, value: 2360}
+      - {offset_seconds: 1140, value: 2480}
+      - {offset_seconds: 1200, value: 2600}
+      - {offset_seconds: 1260, value: 2720}
+  - metric: data
+    labels:
+      job: backend
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 300}
+      - {offset_seconds: 60, value: 480}
+      - {offset_seconds: 120, value: 660}
+      - {offset_seconds: 180, value: 840}
+      - {offset_seconds: 240, value: 1020}
+      - {offset_seconds: 300, value: 1200}
+      - {offset_seconds: 360, value: 1380}
+      - {offset_seconds: 420, value: 1560}
+      - {offset_seconds: 480, value: 1740}
+      - {offset_seconds: 540, value: 1920}
+      - {offset_seconds: 600, value: 2100}
+      - {offset_seconds: 660, value: 2280}
+      - {offset_seconds: 720, value: 2460}
+      - {offset_seconds: 780, value: 2640}
+      - {offset_seconds: 840, value: 2820}
+      - {offset_seconds: 900, value: 3000}
+      - {offset_seconds: 960, value: 3180}
+      - {offset_seconds: 1020, value: 3360}
+      - {offset_seconds: 1080, value: 3540}
+      - {offset_seconds: 1140, value: 3720}
+      - {offset_seconds: 1200, value: 3900}
+      - {offset_seconds: 1260, value: 4080}
+  - metric: data
+    labels:
+      job: backend
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 400}
+      - {offset_seconds: 60, value: 640}
+      - {offset_seconds: 120, value: 880}
+      - {offset_seconds: 180, value: 1120}
+      - {offset_seconds: 240, value: 1360}
+      - {offset_seconds: 300, value: 1600}
+      - {offset_seconds: 360, value: 1840}
+      - {offset_seconds: 420, value: 2080}
+      - {offset_seconds: 480, value: 2320}
+      - {offset_seconds: 540, value: 2560}
+      - {offset_seconds: 600, value: 2800}
+      - {offset_seconds: 660, value: 3040}
+      - {offset_seconds: 720, value: 3280}
+      - {offset_seconds: 780, value: 3520}
+      - {offset_seconds: 840, value: 3760}
+      - {offset_seconds: 900, value: 4000}
+      - {offset_seconds: 960, value: 4240}
+      - {offset_seconds: 1020, value: 4480}
+      - {offset_seconds: 1080, value: 4720}
+      - {offset_seconds: 1140, value: 4960}
+      - {offset_seconds: 1200, value: 5200}
+      - {offset_seconds: 1260, value: 5440}
+  - metric: data
+    labels:
+      job: worker
+      instance: i-1
+    samples:
+      - {offset_seconds: 0, value: 500}
+      - {offset_seconds: 60, value: 800}
+      - {offset_seconds: 120, value: 1100}
+      - {offset_seconds: 180, value: 1400}
+      - {offset_seconds: 240, value: 1700}
+      - {offset_seconds: 300, value: 2000}
+      - {offset_seconds: 360, value: 2300}
+      - {offset_seconds: 420, value: 2600}
+      - {offset_seconds: 480, value: 2900}
+      - {offset_seconds: 540, value: 3200}
+      - {offset_seconds: 600, value: 3500}
+      - {offset_seconds: 660, value: 3800}
+      - {offset_seconds: 720, value: 4100}
+      - {offset_seconds: 780, value: 4400}
+      - {offset_seconds: 840, value: 4700}
+      - {offset_seconds: 900, value: 5000}
+      - {offset_seconds: 960, value: 5300}
+      - {offset_seconds: 1020, value: 5600}
+      - {offset_seconds: 1080, value: 5900}
+      - {offset_seconds: 1140, value: 6200}
+      - {offset_seconds: 1200, value: 6500}
+      - {offset_seconds: 1260, value: 6800}
+  - metric: data
+    labels:
+      job: worker
+      instance: i-2
+    samples:
+      - {offset_seconds: 0, value: 600}
+      - {offset_seconds: 60, value: 960}
+      - {offset_seconds: 120, value: 1320}
+      - {offset_seconds: 180, value: 1680}
+      - {offset_seconds: 240, value: 2040}
+      - {offset_seconds: 300, value: 2400}
+      - {offset_seconds: 360, value: 2760}
+      - {offset_seconds: 420, value: 3120}
+      - {offset_seconds: 480, value: 3480}
+      - {offset_seconds: 540, value: 3840}
+      - {offset_seconds: 600, value: 4200}
+      - {offset_seconds: 660, value: 4560}
+      - {offset_seconds: 720, value: 4920}
+      - {offset_seconds: 780, value: 5280}
+      - {offset_seconds: 840, value: 5640}
+      - {offset_seconds: 900, value: 6000}
+      - {offset_seconds: 960, value: 6360}
+      - {offset_seconds: 1020, value: 6720}
+      - {offset_seconds: 1080, value: 7080}
+      - {offset_seconds: 1140, value: 7440}
+      - {offset_seconds: 1200, value: 7800}
+      - {offset_seconds: 1260, value: 8160}

--- a/promql-compliance/datasets/aggregations-dense-cadence.yaml
+++ b/promql-compliance/datasets/aggregations-dense-cadence.yaml
@@ -9,6 +9,14 @@ series:
   # Each series also has one extra sample at offset_seconds 1260, past the
   # suite's last evaluated offset (1200) so the trailing window has a real
   # later sample to close on, instead of only the wall-clock idle fallback.
+  #
+  # Known gap (roborev job 191): every series shares the same cadence, so
+  # count_over_time(data[5m]) ties across all of them. topk-*-count-over-time
+  # and topk-*-count-over-time-by-job may pick different tied members on
+  # Prometheus vs. ASAPQuery -- not a reliable green signal for those two
+  # query shapes specifically. (topk-*-count-over-time-by-job-instance is
+  # fine: job+instance already uniquely identifies each series, so those
+  # groups have one member each and can't tie.)
   - metric: data
     labels:
       job: frontend

--- a/promql-compliance/runner/Makefile
+++ b/promql-compliance/runner/Makefile
@@ -7,7 +7,8 @@ REPORT_DIR ?= /tmp/asapquery-differential-reports
 CASES := \
 	single-rate-temporal:../datasets/single-rate.yaml:../suites/temporal.yaml \
 	sparse-checkout-temporal:../datasets/sparse-checkout.yaml:../suites/temporal.yaml \
-	aggregations:../datasets/aggregations.yaml:../suites/aggregations.yaml
+	aggregations:../datasets/aggregations.yaml:../suites/aggregations.yaml \
+	aggregations-dense-cadence:../datasets/aggregations-dense-cadence.yaml:../suites/aggregations.yaml
 
 test:
 	go test ./...

--- a/promql-compliance/runner/run.go
+++ b/promql-compliance/runner/run.go
@@ -128,7 +128,45 @@ func Run(ctx context.Context, options RunOptions) (Report, error) {
 		return Report{}, fmt.Errorf("test target did not expose seeded data: %w", err)
 	}
 
+	// Also wait for the suite's LATEST timestamp, not just its earliest:
+	// a streaming target's trailing window can still be open even once
+	// earlier points are ready (#705 follow-up).
+	latestTime, ok := latestEvaluationTime(suite, base)
+	if ok && latestTime.After(probeTime) {
+		if err := waitForData(ctx, reference, probeQuery, latestTime); err != nil {
+			return Report{}, fmt.Errorf("reference target did not close its latest window: %w", err)
+		}
+		if err := waitForData(ctx, test, probeQuery, latestTime); err != nil {
+			return Report{}, fmt.Errorf("test target did not close its latest window: %w", err)
+		}
+	}
+
 	return CompareSuite(ctx, reference, test, suite, fixture.Name, base)
+}
+
+// latestEvaluationTime is the max instant offset / range end across the
+// whole suite -- the last timestamp anything will be evaluated at.
+func latestEvaluationTime(suite Suite, base time.Time) (time.Time, bool) {
+	found := false
+	var latestOffset float64
+	consider := func(offset float64) {
+		if !found || offset > latestOffset {
+			latestOffset = offset
+			found = true
+		}
+	}
+	for _, query := range suite.Queries {
+		for _, offset := range query.InstantOffsetsSeconds {
+			consider(offset)
+		}
+		if query.Range != nil {
+			consider(query.Range.EndOffsetSeconds)
+		}
+	}
+	if !found {
+		return time.Time{}, false
+	}
+	return addSeconds(base, latestOffset), true
 }
 
 func runBaseTime(baseTimeMS int64) time.Time {

--- a/promql-compliance/runner/run.go
+++ b/promql-compliance/runner/run.go
@@ -130,13 +130,16 @@ func Run(ctx context.Context, options RunOptions) (Report, error) {
 
 	// Also wait for the suite's LATEST timestamp, not just its earliest:
 	// a streaming target's trailing window can still be open even once
-	// earlier points are ready (#705 follow-up).
-	latestTime, ok := latestEvaluationTime(suite, base)
+	// earlier points are ready (#705 follow-up). Probe with the query
+	// that timestamp actually belongs to -- suite.Queries[0] may not even
+	// be evaluated that far out, so its own value there proves nothing
+	// (roborev job 191).
+	latestQuery, latestTime, ok := latestEvaluation(suite, base)
 	if ok && latestTime.After(probeTime) {
-		if err := waitForData(ctx, reference, probeQuery, latestTime); err != nil {
+		if err := waitForData(ctx, reference, latestQuery.Expr, latestTime); err != nil {
 			return Report{}, fmt.Errorf("reference target did not close its latest window: %w", err)
 		}
-		if err := waitForData(ctx, test, probeQuery, latestTime); err != nil {
+		if err := waitForData(ctx, test, latestQuery.Expr, latestTime); err != nil {
 			return Report{}, fmt.Errorf("test target did not close its latest window: %w", err)
 		}
 	}
@@ -144,29 +147,33 @@ func Run(ctx context.Context, options RunOptions) (Report, error) {
 	return CompareSuite(ctx, reference, test, suite, fixture.Name, base)
 }
 
-// latestEvaluationTime is the max instant offset / range end across the
-// whole suite -- the last timestamp anything will be evaluated at.
-func latestEvaluationTime(suite Suite, base time.Time) (time.Time, bool) {
+// latestEvaluation is the query and timestamp representing the latest
+// evaluation point across the whole suite (the max instant offset / range
+// end), so a caller can probe readiness with a query actually configured
+// for that timestamp.
+func latestEvaluation(suite Suite, base time.Time) (QueryCase, time.Time, bool) {
 	found := false
+	var latestQuery QueryCase
 	var latestOffset float64
-	consider := func(offset float64) {
+	consider := func(query QueryCase, offset float64) {
 		if !found || offset > latestOffset {
+			latestQuery = query
 			latestOffset = offset
 			found = true
 		}
 	}
 	for _, query := range suite.Queries {
 		for _, offset := range query.InstantOffsetsSeconds {
-			consider(offset)
+			consider(query, offset)
 		}
 		if query.Range != nil {
-			consider(query.Range.EndOffsetSeconds)
+			consider(query, query.Range.EndOffsetSeconds)
 		}
 	}
 	if !found {
-		return time.Time{}, false
+		return QueryCase{}, time.Time{}, false
 	}
-	return addSeconds(base, latestOffset), true
+	return latestQuery, addSeconds(base, latestOffset), true
 }
 
 func runBaseTime(baseTimeMS int64) time.Time {

--- a/promql-compliance/runner/run_test.go
+++ b/promql-compliance/runner/run_test.go
@@ -23,6 +23,31 @@ func TestDataProbeTimeUsesConfiguredEvaluationTime(t *testing.T) {
 	}
 }
 
+func TestLatestEvaluationTimeIsMaxAcrossQueries(t *testing.T) {
+	base := time.UnixMilli(1_700_000_000_000).UTC()
+	suite := Suite{
+		Name: "mixed",
+		Queries: []QueryCase{
+			{Name: "early-instant", InstantOffsetsSeconds: []float64{300, 600}},
+			{Name: "late-range", Range: &RangeSpec{StartOffsetSeconds: 0, EndOffsetSeconds: 1200, StepSeconds: 60}},
+			{Name: "mid-instant", InstantOffsetsSeconds: []float64{900}},
+		},
+	}
+	latest, ok := latestEvaluationTime(suite, base)
+	if !ok {
+		t.Fatal("latestEvaluationTime: expected a result")
+	}
+	if want := base.Add(1200 * time.Second); !latest.Equal(want) {
+		t.Fatalf("latest evaluation time = %s, want %s (the range's end, not the highest instant offset)", latest, want)
+	}
+}
+
+func TestLatestEvaluationTimeEmptySuite(t *testing.T) {
+	if _, ok := latestEvaluationTime(Suite{Name: "empty"}, time.Now()); ok {
+		t.Fatal("latestEvaluationTime: expected no result for a suite with no queries")
+	}
+}
+
 func TestGeneratedConfigsUseCurrentPlannerAndEngineSchema(t *testing.T) {
 	directory := t.TempDir()
 	fixture := seeder.Fixture{

--- a/promql-compliance/runner/run_test.go
+++ b/promql-compliance/runner/run_test.go
@@ -23,28 +23,31 @@ func TestDataProbeTimeUsesConfiguredEvaluationTime(t *testing.T) {
 	}
 }
 
-func TestLatestEvaluationTimeIsMaxAcrossQueries(t *testing.T) {
+func TestLatestEvaluationIsMaxAcrossQueriesAndOwningQuery(t *testing.T) {
 	base := time.UnixMilli(1_700_000_000_000).UTC()
 	suite := Suite{
 		Name: "mixed",
 		Queries: []QueryCase{
-			{Name: "early-instant", InstantOffsetsSeconds: []float64{300, 600}},
-			{Name: "late-range", Range: &RangeSpec{StartOffsetSeconds: 0, EndOffsetSeconds: 1200, StepSeconds: 60}},
-			{Name: "mid-instant", InstantOffsetsSeconds: []float64{900}},
+			{Name: "early-instant", Expr: "early", InstantOffsetsSeconds: []float64{300, 600}},
+			{Name: "late-range", Expr: "late", Range: &RangeSpec{StartOffsetSeconds: 0, EndOffsetSeconds: 1200, StepSeconds: 60}},
+			{Name: "mid-instant", Expr: "mid", InstantOffsetsSeconds: []float64{900}},
 		},
 	}
-	latest, ok := latestEvaluationTime(suite, base)
+	query, latest, ok := latestEvaluation(suite, base)
 	if !ok {
-		t.Fatal("latestEvaluationTime: expected a result")
+		t.Fatal("latestEvaluation: expected a result")
 	}
 	if want := base.Add(1200 * time.Second); !latest.Equal(want) {
 		t.Fatalf("latest evaluation time = %s, want %s (the range's end, not the highest instant offset)", latest, want)
 	}
+	if query.Name != "late-range" {
+		t.Fatalf("latest evaluation query = %q, want %q (the query that timestamp actually belongs to)", query.Name, "late-range")
+	}
 }
 
-func TestLatestEvaluationTimeEmptySuite(t *testing.T) {
-	if _, ok := latestEvaluationTime(Suite{Name: "empty"}, time.Now()); ok {
-		t.Fatal("latestEvaluationTime: expected no result for a suite with no queries")
+func TestLatestEvaluationEmptySuite(t *testing.T) {
+	if _, _, ok := latestEvaluation(Suite{Name: "empty"}, time.Now()); ok {
+		t.Fatal("latestEvaluation: expected no result for a suite with no queries")
 	}
 }
 


### PR DESCRIPTION
## Summary
- #705's root cause is that `sum_over_time`/`count_over_time`/`topk-*-over-time*` are precomputed as a dual-population aggregation (a shared CountMinSketch for values, paired with a shared DeltaSetAggregator for keys). A series that samples slower than the query step toggles present/absent in the DeltaSetAggregator's per-bucket delta chain, so it silently drops out of the windowed result at every other step even though the CMS has real data for it -- confirmed against real PromQL range-vector semantics (any sample anywhere in the window is sufficient; no boundary-alignment requirement).
- This PR doesn't fix that yet -- it isolates it in the compliance suite. `aggregations.yaml` (backend/i-2 and worker/i-2 sample slower than the 60s query step) is left untouched as the red case tracking #705. New `datasets/aggregations-dense-cadence.yaml` is the same fixture at uniform 60s cadence, giving a green baseline for the same query shapes, wired into `runner/Makefile`'s `CASES`.
- Also fixes a separate, unrelated bug the isolation surfaced: the differential-runner only waited for the suite's *earliest* evaluation point before comparing, so a streaming target's trailing window (which needs its watermark to advance past the window's right edge to close) could still be open at comparison time. `run.go` now also waits for the suite's latest evaluation timestamp. Where that alone wasn't enough (the trailing window's only remaining sample *is* the last evaluated point, so it has no later sample to close on except the wall-clock idle fallback -- undetectable by polling for presence), `aggregations-dense-cadence.yaml` carries one extra sample past the suite's last evaluated offset so the window closes normally.

## Test plan
- [x] `cd promql-compliance/runner && go test ./...`
- [x] `go run ./cmd/differential-runner --dataset ../datasets/aggregations-dense-cadence.yaml --suite ../suites/aggregations.yaml --compose-file ../docker-compose.yml`: `sum-over-time`, `count-over-time`, and the plain instant `sum`/`count` now pass (60/62 failing -> 41/62). Remaining failures (`quantile-*`, `topk-*-over-time*`) are unrelated pre-existing issues, not touched here.
- [x] `aggregations.yaml` (unchanged) still fails the same way, still tracking #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)