### PR TITLE
fix: resolve roborev findings for jobs 185 and 187

### DIFF
--- a/asap-common/dependencies/py/promql_utilities/promql_utilities/query_logics/logics.py
+++ b/asap-common/dependencies/py/promql_utilities/promql_utilities/query_logics/logics.py
@@ -97,9 +97,12 @@ def does_precompute_operator_support_subpopulations(
     elif (
         precompute_operator == "CountMinSketchWithHeap" and statistic == Statistic.TOPK
     ):
-        # topk and bottomk do not support subpopulations!
-        # other usages of CountMinSketchWithHeap will fall through.
-        return False
+        # CountMinSketchWithHeap (topk) is a heavy-hitters sketch: one heap
+        # instance tracks many keys internally (like MultipleSum), it just
+        # doesn't need an *external* paired key aggregation to enumerate them
+        # -- it discovers its own top-k keys. So it supports subpopulations
+        # the same way MultipleSum does.
+        return True
     # elif precompute_operator == "UnivMon":
     #     return statistic in ["sum", "count", "avg"]
     else:

--- a/asap-common/dependencies/rs/asap_types/src/capability_matching.rs
+++ b/asap-common/dependencies/rs/asap_types/src/capability_matching.rs
@@ -262,15 +262,16 @@ pub fn find_compatible_aggregation(
         return Err(CapabilityMatchingError::MissingTopkWeighting);
     }
 
-    let mut configs_by_id: Vec<&AggregationConfig> = configs.values().collect();
-    configs_by_id.sort_by_key(|config| config.aggregation_id);
-    for config in configs_by_id {
-        config.validate()?;
-    }
-
     if requirements.statistics.is_empty() {
         return Ok(None);
     }
+
+    // Configs are validated lazily below, scoped to only those actually
+    // considered as candidates for the current requirement -- a malformed
+    // config for an unrelated metric/type must not fail queries that would
+    // never have selected it.
+    let mut configs_by_id: Vec<&AggregationConfig> = configs.values().collect();
+    configs_by_id.sort_by_key(|config| config.aggregation_id);
 
     debug!(
         metric = %requirements.metric,
@@ -288,34 +289,53 @@ pub fn find_compatible_aggregation(
         let types = compatible_agg_types(stat);
         let sub_type = required_sub_type(stat);
 
-        let mut candidates: Vec<&AggregationConfig> = configs
-            .values()
-            .filter(|c| {
-                let ok = c.metric == requirements.metric
-                    && types.contains(&c.aggregation_type)
-                    && sub_type.is_none_or(|st| c.aggregation_sub_type.eq_ignore_ascii_case(st))
-                    && window_compatible(c, requirements.data_range_ms)
-                    && labels_compatible(&c.grouping_labels, &requirements.grouping_labels)
-                    && spatial_filter_compatible(
-                        &c.spatial_filter_normalized,
-                        &requirements.spatial_filter_normalized,
-                    )
-                    && plain_cms_sub_type_compatible(stat, c)
-                    && topk_weighting_compatible(stat, c, requirements.topk_count_events)
-                    && count_heap_weighting_compatible(stat, c);
-                if !ok {
-                    debug!(
-                        agg_id = c.aggregation_id,
-                        agg_type = %c.aggregation_type,
-                        metric = %c.metric,
-                        window_size_ms = c.window_size_ms,
-                        "capability matching: rejected config for {:?}",
-                        stat,
-                    );
-                }
-                ok
-            })
-            .collect();
+        let mut candidates: Vec<&AggregationConfig> = Vec::new();
+        for &c in &configs_by_id {
+            let basic_ok = c.metric == requirements.metric
+                && types.contains(&c.aggregation_type)
+                && sub_type.is_none_or(|st| c.aggregation_sub_type.eq_ignore_ascii_case(st))
+                && window_compatible(c, requirements.data_range_ms)
+                && labels_compatible(&c.grouping_labels, &requirements.grouping_labels)
+                && spatial_filter_compatible(
+                    &c.spatial_filter_normalized,
+                    &requirements.spatial_filter_normalized,
+                );
+            if !basic_ok {
+                debug!(
+                    agg_id = c.aggregation_id,
+                    agg_type = %c.aggregation_type,
+                    metric = %c.metric,
+                    window_size_ms = c.window_size_ms,
+                    "capability matching: rejected config for {:?}",
+                    stat,
+                );
+                continue;
+            }
+
+            // Only validate configs that are actually relevant to this
+            // requirement (basic_ok above): `topk_weighting_compatible` /
+            // `count_heap_weighting_compatible` rely on `count_events` being
+            // present and boolean on any CountMinSketchWithHeap candidate.
+            if c.aggregation_type == AggregationType::CountMinSketchWithHeap {
+                c.validate()?;
+            }
+
+            let ok = plain_cms_sub_type_compatible(stat, c)
+                && topk_weighting_compatible(stat, c, requirements.topk_count_events)
+                && count_heap_weighting_compatible(stat, c);
+            if !ok {
+                debug!(
+                    agg_id = c.aggregation_id,
+                    agg_type = %c.aggregation_type,
+                    metric = %c.metric,
+                    window_size_ms = c.window_size_ms,
+                    "capability matching: rejected config for {:?}",
+                    stat,
+                );
+                continue;
+            }
+            candidates.push(c);
+        }
 
         candidates.sort_by(|a, b| aggregation_priority(a, b));
 
@@ -1730,6 +1750,36 @@ mod tests {
                 AggregationConfigError::MissingCountEvents { aggregation_id: 7 }
             )
         ));
+    }
+
+    #[test]
+    fn malformed_heap_config_on_unrelated_metric_does_not_break_matching() {
+        // A malformed CountMinSketchWithHeap config for a metric no part of
+        // this query cares about must not fail matching for that query --
+        // validation is scoped to configs actually considered as candidates,
+        // not applied unconditionally across the whole config map (#roborev).
+        let mut configs = HashMap::new();
+        let mut malformed = make_config(
+            7,
+            "other_table",
+            "CountMinSketchWithHeap",
+            "",
+            1_000,
+            "tumbling",
+            &[],
+            "",
+        );
+        malformed.parameters.remove("count_events");
+        configs.insert(7, malformed);
+        configs.insert(
+            1,
+            make_config(1, "cpu", "Sum", "", 300_000, "tumbling", &[], ""),
+        );
+
+        let result =
+            find_compatible_aggregation(&configs, &req("cpu", &[Statistic::Sum], 300_000, &[], ""));
+        let info = result.expect("unrelated malformed heap config must not break this match");
+        assert_eq!(info.aggregation_id_for_value, 1);
     }
 
     #[test]

--- a/asap-planner-rs/src/planner/sql.rs
+++ b/asap-planner-rs/src/planner/sql.rs
@@ -141,7 +141,7 @@ impl SQLSingleQueryProcessor {
         let topk_k = sql_topk.map(|t| t.k);
         let topk_count_events = sql_topk.map(|t| t.count_events());
 
-        let mut configs = build_agg_configs_for_statistics(
+        let configs = build_agg_configs_for_statistics(
             &statistics,
             treatment_type,
             &spatial_output,
@@ -162,17 +162,6 @@ impl SQLSingleQueryProcessor {
             },
         )
         .map_err(ControllerError::SqlParse)?;
-
-        if sql_topk.is_some() {
-            for cfg in &mut configs {
-                if cfg.aggregation_type == AggregationType::CountMinSketchWithHeap {
-                    // Heap-only self-keyed layout: the GROUP BY column is tracked
-                    // inside the sketch's aggregated dimension, not as a partition key.
-                    cfg.grouping_labels = KeyByLabelNames::empty();
-                    cfg.aggregated_labels = spatial_output.clone();
-                }
-            }
-        }
 
         // SQLPatternParser always produces second-based durations; convert to ms.
         // For a single-scrape-interval query this equals data_ingestion_interval_ms


### PR DESCRIPTION
## Summary
- Scope `find_compatible_aggregation`'s `CountMinSketchWithHeap` config validation to only the configs actually considered as candidates for the current query, instead of validating every config in the map upfront — a malformed config for an unrelated metric/type no longer breaks capability matching for queries that would never have selected it (roborev job 185, both High findings).
- Sync the Python copy of `does_precompute_operator_support_subpopulations` with the Rust fix for `CountMinSketchWithHeap` + `TOPK` (roborev job 187, Medium finding).
- Remove the now-redundant manual grouping/aggregated-label override in `asap-planner-rs/src/planner/sql.rs`, since `build_agg_configs_for_statistics` already produces the same split (roborev job 187, Low finding).

## Test plan
- [x] `cargo test -p asap_types` (70 passed, incl. new regression test `malformed_heap_config_on_unrelated_metric_does_not_break_matching`)
- [x] `cargo test -p query_engine_rust --lib` (632 passed)
- [x] `cargo test -p asap_planner` (110 lib + 49 integration + 38 sql_integration + others, 0 failed)
- [x] `cargo clippy` on affected crates: no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V66Z7Fge2EYW2N1CDJzrxk